### PR TITLE
Optimize mask computation and add optional inference outputs

### DIFF
--- a/configs/deimv2/deimv2_dinov3_s_wholebody40_ins.yml
+++ b/configs/deimv2/deimv2_dinov3_s_wholebody40_ins.yml
@@ -33,6 +33,8 @@ DEIMTransformer:
   eval_idx: -1
   num_queries: 800
   mask_feature_level: 1 # 0=stride8, 1=stride16, 2=stride32
+  mask_embed_head_hidden_dim: 96
+  mask_embed_head_num_layers: 2
   use_contour_aux_head: False
   use_distance_aux_head: False
   aux_mask_feature_level: 1

--- a/configs/deimv2/deimv2_dinov3_s_wholebody40_ins.yml
+++ b/configs/deimv2/deimv2_dinov3_s_wholebody40_ins.yml
@@ -7,6 +7,7 @@ __include__: [
 ]
 
 output_dir: ./outputs/deimv2_dinov3_s_wholebody40_ins
+mask_target_class_ids: [0]
 
 DEIM:
   backbone: DINOv3STAs
@@ -33,14 +34,16 @@ DEIMTransformer:
   eval_idx: -1
   num_queries: 800
   mask_feature_level: 1 # 0=stride8, 1=stride16, 2=stride32
+  mask_compute_mode: lazy
   mask_embed_head_hidden_dim: 96
   mask_embed_head_num_layers: 2
-  use_contour_aux_head: False
-  use_distance_aux_head: False
+  use_contour_aux_head: True
+  use_distance_aux_head: True
   aux_mask_feature_level: 1
 
 PostProcessor:
   num_top_queries: 800
+  k_max: 0
 
 optimizer:
   type: AdamW
@@ -120,11 +123,11 @@ DEIMCriterion:
     loss_mask_contour: 0.5
     loss_mask_distance: 0.25
   losses: ['mal', 'boxes', 'local', 'masks']
-  use_boundary_aware_loss: False
+  use_boundary_aware_loss: True
   boundary_aware_width: 3
   boundary_aware_weight: 2.0
-  use_contour_detection: False
-  use_distance_transform: False
+  use_contour_detection: True
+  use_distance_transform: True
   distance_transform_steps: 5
   matcher:
     change_matcher: True

--- a/configs/deimv2/deimv2_dinov3_s_wholebody40_ins_s08.yml
+++ b/configs/deimv2/deimv2_dinov3_s_wholebody40_ins_s08.yml
@@ -7,6 +7,7 @@ __include__: [
 ]
 
 output_dir: ./outputs/deimv2_dinov3_s_wholebody40_ins
+mask_target_class_ids: [0]
 
 DEIM:
   backbone: DINOv3STAs
@@ -33,12 +34,16 @@ DEIMTransformer:
   eval_idx: -1
   num_queries: 800
   mask_feature_level: 0 # 0=stride8, 1=stride16, 2=stride32
-  use_contour_aux_head: False
-  use_distance_aux_head: False
+  mask_compute_mode: lazy
+  mask_embed_head_hidden_dim: 96
+  mask_embed_head_num_layers: 2
+  use_contour_aux_head: True
+  use_distance_aux_head: True
   aux_mask_feature_level: 0 # 0=stride8, 1=stride16, 2=stride32
 
 PostProcessor:
   num_top_queries: 800
+  k_max: 0
 
 optimizer:
   type: AdamW
@@ -118,11 +123,11 @@ DEIMCriterion:
     loss_mask_contour: 0.5
     loss_mask_distance: 0.25
   losses: ['mal', 'boxes', 'local', 'masks']
-  use_boundary_aware_loss: False
+  use_boundary_aware_loss: True
   boundary_aware_width: 3
   boundary_aware_weight: 2.0
-  use_contour_detection: False
-  use_distance_transform: False
+  use_contour_detection: True
+  use_distance_transform: True
   distance_transform_steps: 5
   matcher:
     change_matcher: True

--- a/configs/deimv2/deimv2_dinov3_s_wholebody40_ins_s16.yml
+++ b/configs/deimv2/deimv2_dinov3_s_wholebody40_ins_s16.yml
@@ -7,6 +7,7 @@ __include__: [
 ]
 
 output_dir: ./outputs/deimv2_dinov3_s_wholebody40_ins
+mask_target_class_ids: [0]
 
 DEIM:
   backbone: DINOv3STAs
@@ -33,12 +34,16 @@ DEIMTransformer:
   eval_idx: -1
   num_queries: 800
   mask_feature_level: 1 # 0=stride8, 1=stride16, 2=stride32
-  use_contour_aux_head: False
-  use_distance_aux_head: False
+  mask_compute_mode: lazy
+  mask_embed_head_hidden_dim: 96
+  mask_embed_head_num_layers: 2
+  use_contour_aux_head: True
+  use_distance_aux_head: True
   aux_mask_feature_level: 1 # 0=stride8, 1=stride16, 2=stride32
 
 PostProcessor:
   num_top_queries: 800
+  k_max: 0
 
 optimizer:
   type: AdamW
@@ -118,11 +123,11 @@ DEIMCriterion:
     loss_mask_contour: 0.5
     loss_mask_distance: 0.25
   losses: ['mal', 'boxes', 'local', 'masks']
-  use_boundary_aware_loss: False
+  use_boundary_aware_loss: True
   boundary_aware_width: 3
   boundary_aware_weight: 2.0
-  use_contour_detection: False
-  use_distance_transform: False
+  use_contour_detection: True
+  use_distance_transform: True
   distance_transform_steps: 5
   matcher:
     change_matcher: True

--- a/configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s08.yml
+++ b/configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s08.yml
@@ -8,6 +8,7 @@ __include__: [
 
 
 output_dir: ./outputs/deimv2_dinov3_x_wholebody40_ins
+mask_target_class_ids: [0]
 
 DEIM:
   backbone: DINOv3STAs
@@ -35,6 +36,7 @@ DEIMTransformer:
   hidden_dim: 256
   dim_feedforward: 2048
   mask_feature_level: 0 # 0=stride8, 1=stride16, 2=stride32
+  mask_compute_mode: lazy
   use_contour_aux_head: True
   use_distance_aux_head: True
   aux_mask_feature_level: 0 # 0=stride8, 1=stride16, 2=stride32

--- a/configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s08.yml
+++ b/configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s08.yml
@@ -37,6 +37,8 @@ DEIMTransformer:
   dim_feedforward: 2048
   mask_feature_level: 0 # 0=stride8, 1=stride16, 2=stride32
   mask_compute_mode: lazy
+  mask_embed_head_hidden_dim: 128
+  mask_embed_head_num_layers: 2
   use_contour_aux_head: True
   use_distance_aux_head: True
   aux_mask_feature_level: 0 # 0=stride8, 1=stride16, 2=stride32

--- a/configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s08.yml
+++ b/configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s08.yml
@@ -45,6 +45,7 @@ DEIMTransformer:
 
 PostProcessor:
   num_top_queries: 800
+  k_max: 0
 
 epoches: 58
 

--- a/configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s16.yml
+++ b/configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s16.yml
@@ -8,6 +8,7 @@ __include__: [
 
 
 output_dir: ./outputs/deimv2_dinov3_x_wholebody40_ins
+mask_target_class_ids: [0]
 
 DEIM:
   backbone: DINOv3STAs
@@ -35,12 +36,16 @@ DEIMTransformer:
   hidden_dim: 256
   dim_feedforward: 2048
   mask_feature_level: 1 # 0=stride8, 1=stride16, 2=stride32
+  mask_compute_mode: lazy
+  mask_embed_head_hidden_dim: 128
+  mask_embed_head_num_layers: 2
   use_contour_aux_head: True
   use_distance_aux_head: True
   aux_mask_feature_level: 1 # 0=stride8, 1=stride16, 2=stride32
 
 PostProcessor:
   num_top_queries: 800
+  k_max: 0
 
 epoches: 58
 

--- a/configs/deimv2/deimv2_hgnetv2_atto_wholebody40_ins.yml
+++ b/configs/deimv2/deimv2_hgnetv2_atto_wholebody40_ins.yml
@@ -41,6 +41,8 @@ DEIMTransformer:
   share_bbox_head: True
   use_gateway: False
   mask_feature_level: 0 # 0=stride16, 1=stride32
+  mask_embed_head_hidden_dim: 32
+  mask_embed_head_num_layers: 2
   use_contour_aux_head: False
   use_distance_aux_head: False
   aux_mask_feature_level: 0 # 0=stride16, 1=stride32

--- a/configs/deimv2/deimv2_hgnetv2_atto_wholebody40_ins.yml
+++ b/configs/deimv2/deimv2_hgnetv2_atto_wholebody40_ins.yml
@@ -7,6 +7,7 @@ __include__: [
 ]
 
 output_dir: ./outputs/deimv2_hgnetv2_atto_wholebody40_ins
+mask_target_class_ids: [0]
 
 DEIM:
   encoder: LiteEncoder
@@ -41,14 +42,16 @@ DEIMTransformer:
   share_bbox_head: True
   use_gateway: False
   mask_feature_level: 0 # 0=stride16, 1=stride32
+  mask_compute_mode: lazy
   mask_embed_head_hidden_dim: 32
   mask_embed_head_num_layers: 2
-  use_contour_aux_head: False
-  use_distance_aux_head: False
+  use_contour_aux_head: True
+  use_distance_aux_head: True
   aux_mask_feature_level: 0 # 0=stride16, 1=stride32
 
 PostProcessor:
   num_top_queries: 340
+  k_max: 0
 
 epoches: 500
 
@@ -127,11 +130,11 @@ DEIMCriterion:
     loss_mask_distance: 0.25
   losses: ['mal', 'boxes', 'masks']
   use_uni_set: False
-  use_boundary_aware_loss: False
+  use_boundary_aware_loss: True
   boundary_aware_width: 3
   boundary_aware_weight: 2.0
-  use_contour_detection: False
-  use_distance_transform: False
+  use_contour_detection: True
+  use_distance_transform: True
   distance_transform_steps: 5
 
   matcher:

--- a/configs/deimv2/deimv2_hgnetv2_femto_wholebody40_ins.yml
+++ b/configs/deimv2/deimv2_hgnetv2_femto_wholebody40_ins.yml
@@ -42,6 +42,8 @@ DEIMTransformer:
   share_bbox_head: True
   use_gateway: False
   mask_feature_level: 0 # 0=stride16, 1=stride32
+  mask_embed_head_hidden_dim: 48
+  mask_embed_head_num_layers: 2
   use_contour_aux_head: False
   use_distance_aux_head: False
   aux_mask_feature_level: 0 # 0=stride16, 1=stride32

--- a/configs/deimv2/deimv2_hgnetv2_femto_wholebody40_ins.yml
+++ b/configs/deimv2/deimv2_hgnetv2_femto_wholebody40_ins.yml
@@ -7,6 +7,7 @@ __include__: [
 ]
 
 output_dir: ./outputs/deimv2_hgnetv2_femto_wholebody40_ins
+mask_target_class_ids: [0]
 
 DEIM:
   encoder: LiteEncoder
@@ -42,14 +43,16 @@ DEIMTransformer:
   share_bbox_head: True
   use_gateway: False
   mask_feature_level: 0 # 0=stride16, 1=stride32
+  mask_compute_mode: lazy
   mask_embed_head_hidden_dim: 48
   mask_embed_head_num_layers: 2
-  use_contour_aux_head: False
-  use_distance_aux_head: False
+  use_contour_aux_head: True
+  use_distance_aux_head: True
   aux_mask_feature_level: 0 # 0=stride16, 1=stride32
 
 PostProcessor:
   num_top_queries: 340
+  k_max: 0
 
 epoches: 500
 
@@ -132,11 +135,11 @@ DEIMCriterion:
     loss_mask_distance: 0.25
   losses: ['mal', 'boxes', 'masks']
   use_uni_set: False
-  use_boundary_aware_loss: False
+  use_boundary_aware_loss: True
   boundary_aware_width: 3
   boundary_aware_weight: 2.0
-  use_contour_detection: False
-  use_distance_transform: False
+  use_contour_detection: True
+  use_distance_transform: True
   distance_transform_steps: 5
 
   matcher:

--- a/configs/deimv2/deimv2_hgnetv2_n_wholebody40_ins.yml
+++ b/configs/deimv2/deimv2_hgnetv2_n_wholebody40_ins.yml
@@ -7,6 +7,7 @@ __include__: [
 ]
 
 output_dir: ./outputs/deimv2_hgnetv2_n_wholebody40_ins
+mask_target_class_ids: [0]
 
 HGNetv2:
   name: 'B0'
@@ -40,14 +41,16 @@ DEIMTransformer:
   num_queries: 800
   dim_feedforward: 512
   mask_feature_level: 0 # 0=stride16, 1=stride32
+  mask_compute_mode: lazy
   mask_embed_head_hidden_dim: 64
   mask_embed_head_num_layers: 2
-  use_contour_aux_head: False
-  use_distance_aux_head: False
+  use_contour_aux_head: True
+  use_distance_aux_head: True
   aux_mask_feature_level: 0 # 0=stride16, 1=stride32
 
 PostProcessor:
   num_top_queries: 800
+  k_max: 0
 
 optimizer:
   type: AdamW
@@ -128,11 +131,11 @@ DEIMCriterion:
     loss_mask_contour: 0.5
     loss_mask_distance: 0.25
   losses: ['mal', 'boxes', 'local', 'masks']
-  use_boundary_aware_loss: False
+  use_boundary_aware_loss: True
   boundary_aware_width: 3
   boundary_aware_weight: 2.0
-  use_contour_detection: False
-  use_distance_transform: False
+  use_contour_detection: True
+  use_distance_transform: True
   distance_transform_steps: 5
   matcher:
     change_matcher: True

--- a/configs/deimv2/deimv2_hgnetv2_n_wholebody40_ins.yml
+++ b/configs/deimv2/deimv2_hgnetv2_n_wholebody40_ins.yml
@@ -40,6 +40,8 @@ DEIMTransformer:
   num_queries: 800
   dim_feedforward: 512
   mask_feature_level: 0 # 0=stride16, 1=stride32
+  mask_embed_head_hidden_dim: 64
+  mask_embed_head_num_layers: 2
   use_contour_aux_head: False
   use_distance_aux_head: False
   aux_mask_feature_level: 0 # 0=stride16, 1=stride32

--- a/configs/deimv2/deimv2_hgnetv2_pico_wholebody40_ins.yml
+++ b/configs/deimv2/deimv2_hgnetv2_pico_wholebody40_ins.yml
@@ -43,6 +43,8 @@ DEIMTransformer:
   share_bbox_head: True
   use_gateway: False
   mask_feature_level: 0 # 0=stride16, 1=stride32
+  mask_embed_head_hidden_dim: 56
+  mask_embed_head_num_layers: 2
   use_contour_aux_head: False
   use_distance_aux_head: False
   aux_mask_feature_level: 0 # 0=stride16, 1=stride32

--- a/configs/deimv2/deimv2_hgnetv2_pico_wholebody40_ins.yml
+++ b/configs/deimv2/deimv2_hgnetv2_pico_wholebody40_ins.yml
@@ -7,6 +7,7 @@ __include__: [
 ]
 
 output_dir: ./outputs/deimv2_hgnetv2_pico_wholebody40_ins
+mask_target_class_ids: [0]
 
 DEIM:
   encoder: LiteEncoder
@@ -43,14 +44,16 @@ DEIMTransformer:
   share_bbox_head: True
   use_gateway: False
   mask_feature_level: 0 # 0=stride16, 1=stride32
+  mask_compute_mode: lazy
   mask_embed_head_hidden_dim: 56
   mask_embed_head_num_layers: 2
-  use_contour_aux_head: False
-  use_distance_aux_head: False
+  use_contour_aux_head: True
+  use_distance_aux_head: True
   aux_mask_feature_level: 0 # 0=stride16, 1=stride32
 
 PostProcessor:
   num_top_queries: 340
+  k_max: 0
 
 epoches: 500
 
@@ -132,11 +135,11 @@ DEIMCriterion:
     loss_mask_distance: 0.25
   losses: ['mal', 'boxes', 'masks']
   use_uni_set: False
-  use_boundary_aware_loss: False
+  use_boundary_aware_loss: True
   boundary_aware_width: 3
   boundary_aware_weight: 2.0
-  use_contour_detection: False
-  use_distance_transform: False
+  use_contour_detection: True
+  use_distance_transform: True
   distance_transform_steps: 5
 
   matcher:

--- a/demo/wholebody40/README.md
+++ b/demo/wholebody40/README.md
@@ -112,7 +112,8 @@ uv run python demo/wholebody40/demo_deimv2_torch_wholebody40_ins.py \
 --disable_generation_identification_mode \
 --disable_gender_identification_mode \
 --disable_headpose_identification_mode \
---disable_head_distance_measurement
+--disable_head_distance_measurement \
+--enable-masks
 ```
 
 - Runs inference on all `jpg/jpeg/png/bmp/webp` images in the input folder.
@@ -121,6 +122,35 @@ uv run python demo/wholebody40/demo_deimv2_torch_wholebody40_ins.py \
 - Body mask resize uses `center` origin by default. You can compare against the legacy behavior with `--mask_resize_origin topleft`.
 - If you specify `--disable_render_classids 0`, both the body bounding box and the body mask are hidden.
 - If you add `--save_raw_predictions`, the script saves `labels/scores/boxes` and body `mask_area/mask_bbox` to `predictions/*.json`.
+
+### ONNX model
+You can also pass an exported ONNX model to `-r/--resume`. In that case the same demo script switches to ONNX Runtime automatically.
+
+```bash
+uv run python demo/wholebody40/demo_deimv2_torch_wholebody40_ins.py \
+-c configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s08.yml \
+-r deimv2_dinov3_x_wholebody40_ins_s08_800query_masks.onnx \
+-i images_partial \
+-o outputs/demo_wholebody40_onnx_ins_s08 \
+--enable-masks
+```
+
+### ONNX with TensorRT
+If `onnxruntime` was built with `TensorrtExecutionProvider`, you can enable TensorRT only for the ONNX path with `-d tensorrt`.
+
+```bash
+uv run python demo/wholebody40/demo_deimv2_torch_wholebody40_ins.py \
+-c configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s08.yml \
+-r deimv2_dinov3_x_wholebody40_ins_s08_800query_masks.onnx \
+-i images_partial \
+-o outputs/demo_wholebody40_trt_ins_s08 \
+-d tensorrt \
+--enable-masks
+```
+
+- `-d tensorrt` is supported only when `-r/--resume` points to an `.onnx` file.
+- Supported values for `--inference_type` are `fp16` and `int8`.
+- The TensorRT engine cache is created next to the ONNX file on first run, so the first invocation can take longer.
 
 |Image|Image|
 |:-:|:-:|

--- a/demo/wholebody40/demo_deimv2_torch_wholebody40_ins.py
+++ b/demo/wholebody40/demo_deimv2_torch_wholebody40_ins.py
@@ -380,10 +380,15 @@ def prepare_prediction_payload(
     boxes: List[Box],
     result: Dict[str, torch.Tensor],
     mask_threshold: float,
+    enable_masks: bool,
+    enable_contours: bool,
 ) -> List[Dict[str, object]]:
-    masks = result.get('masks')
+    masks = result.get('masks') if enable_masks else None
     if masks is not None:
         masks = masks.detach().cpu()
+    contours = result.get('contours') if enable_contours else None
+    if contours is not None:
+        contours = contours.detach().cpu()
 
     records: List[Dict[str, object]] = []
     for box in boxes:
@@ -403,6 +408,13 @@ def prepare_prediction_payload(
             if mask_bbox is not None:
                 record['mask_area'] = int(binary_mask.sum())
                 record['mask_bbox'] = mask_bbox
+
+        if contours is not None and box.classid == BODY_CLASS_ID and box.source_idx >= 0:
+            binary_contour = contours[box.source_idx, 0].numpy() >= mask_threshold
+            contour_bbox = binary_mask_bbox(binary_contour)
+            if contour_bbox is not None:
+                record['contour_area'] = int(binary_contour.sum())
+                record['contour_bbox'] = contour_bbox
 
         records.append(record)
     return records
@@ -440,6 +452,45 @@ def overlay_body_masks(
     base = image.convert('RGBA')
     mask_image = Image.fromarray(overlay)
     return Image.alpha_composite(base, mask_image).convert('RGB')
+
+
+def overlay_body_contours(
+    image: Image.Image,
+    result: Dict[str, torch.Tensor],
+    boxes: List[Box],
+    contour_threshold: float,
+    disable_render_classids: set[int],
+) -> Image.Image:
+    contours = result.get('contours')
+    if contours is None or BODY_CLASS_ID in disable_render_classids:
+        return image
+
+    contours = contours.detach().cpu()
+    rendered = cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
+    body_instance_idx = 0
+
+    for box in boxes:
+        if box.classid != BODY_CLASS_ID or box.source_idx < 0:
+            continue
+        binary_contour = (contours[box.source_idx, 0].numpy() >= contour_threshold).astype(np.uint8)
+        if not binary_contour.any():
+            continue
+
+        contour_segments, _ = cv2.findContours(binary_contour, cv2.RETR_LIST, cv2.CHAIN_APPROX_NONE)
+        if not contour_segments:
+            continue
+
+        instance_color = make_instance_color(body_instance_idx)
+        cv2.drawContours(
+            rendered,
+            contour_segments,
+            contourIdx=-1,
+            color=(instance_color[2], instance_color[1], instance_color[0]),
+            thickness=1,
+        )
+        body_instance_idx += 1
+
+    return Image.fromarray(cv2.cvtColor(rendered, cv2.COLOR_BGR2RGB))
 
 
 def draw_dashed_line(
@@ -852,11 +903,26 @@ class InferenceModel(nn.Module):
         self.device = device
 
     @torch.inference_mode()
-    def forward(self, image_tensor: torch.Tensor, orig_target_sizes: torch.Tensor):
-        outputs = self.model(image_tensor)
+    def forward(
+        self,
+        image_tensor: torch.Tensor,
+        orig_target_sizes: torch.Tensor,
+        return_masks: bool=False,
+        return_contours: bool=False,
+    ):
+        outputs = self.model(
+            image_tensor,
+            return_masks=return_masks,
+            return_contours=return_contours,
+        )
         outputs = move_to_device(outputs, torch.device('cpu'))
         orig_target_sizes = orig_target_sizes.to('cpu')
-        return self.postprocessor(outputs, orig_target_sizes)
+        return self.postprocessor(
+            outputs,
+            orig_target_sizes,
+            return_masks=return_masks,
+            return_contours=return_contours,
+        )
 
 
 def save_predictions_json(output_dir: Path, image_path: Path, records: List[Dict[str, object]]) -> None:
@@ -912,6 +978,8 @@ def process_images(args) -> None:
     print(f'Using checkpoint: {resume_path}')
     print(f'Output directory: {output_dir}')
     print(f'Mask resize origin: {args.mask_resize_origin}')
+    print(f'Enable masks: {args.enable_masks}')
+    print(f'Enable contours: {args.enable_contours}')
 
     for image_path in tqdm(
         image_paths,
@@ -924,7 +992,12 @@ def process_images(args) -> None:
         orig_target_sizes = torch.tensor([[orig_w, orig_h]], dtype=torch.float32)
         image_tensor = transform(image).unsqueeze(0).to(device)
 
-        results = model(image_tensor, orig_target_sizes)
+        results = model(
+            image_tensor,
+            orig_target_sizes,
+            return_masks=args.enable_masks,
+            return_contours=args.enable_contours,
+        )
         result = results[0]
 
         boxes = build_result_boxes(
@@ -946,6 +1019,13 @@ def process_images(args) -> None:
             boxes=boxes,
             mask_threshold=args.mask_threshold,
             mask_alpha=args.mask_alpha,
+            disable_render_classids=disable_render_classids,
+        )
+        rendered = overlay_body_contours(
+            image=rendered,
+            result=result,
+            boxes=boxes,
+            contour_threshold=args.mask_threshold,
             disable_render_classids=disable_render_classids,
         )
         rendered = draw_detections(
@@ -970,6 +1050,8 @@ def process_images(args) -> None:
                 boxes=boxes,
                 result=result,
                 mask_threshold=args.mask_threshold,
+                enable_masks=args.enable_masks,
+                enable_contours=args.enable_contours,
             )
             save_predictions_json(output_dir, image_path, records)
 
@@ -1000,6 +1082,8 @@ def parse_args():
     parser.add_argument('--mask_threshold', type=float, default=0.5)
     parser.add_argument('--mask_alpha', type=check_alpha, default=128)
     parser.add_argument('--mask_resize_origin', type=str, choices=['topleft', 'center'], default='topleft')
+    parser.add_argument('--enable-masks', action='store_true')
+    parser.add_argument('--enable-contours', action='store_true')
     parser.add_argument('--keypoint_drawing_mode', type=str, choices=['dot', 'box', 'both'], default='dot')
     parser.add_argument('--enable_bone_drawing_mode', action='store_true')
     parser.add_argument('--disable_generation_identification_mode', action='store_true')

--- a/demo/wholebody40/demo_deimv2_torch_wholebody40_ins.py
+++ b/demo/wholebody40/demo_deimv2_torch_wholebody40_ins.py
@@ -22,7 +22,8 @@ from PIL import Image, ImageColor
 from tqdm import tqdm
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-from engine.core import YAMLConfig
+from engine.core import YAMLConfig, load_config
+from engine.misc.mask_resize import resize_masks
 
 
 AVERAGE_HEAD_WIDTH: float = 0.16 + 0.10
@@ -168,6 +169,61 @@ def resolve_device(device_arg: str | None) -> torch.device:
     if device_arg:
         return torch.device(device_arg)
     return torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+
+def is_onnx_model(model_path: Path) -> bool:
+    return model_path.suffix.lower() == '.onnx'
+
+
+def build_onnx_providers(device_arg: str | None, model_path: Path, inference_type: str):
+    import onnxruntime as ort
+
+    available_providers = set(ort.get_available_providers())
+    requested = (device_arg or '').lower()
+    inference_type = inference_type.lower()
+
+    if requested.startswith('cuda'):
+        if 'CUDAExecutionProvider' not in available_providers:
+            raise RuntimeError('CUDAExecutionProvider is not available in this onnxruntime build.')
+        return ['CUDAExecutionProvider', 'CPUExecutionProvider']
+
+    if requested == 'tensorrt':
+        if 'TensorrtExecutionProvider' not in available_providers:
+            raise RuntimeError('TensorrtExecutionProvider is not available in this onnxruntime build.')
+        ep_type_params = {}
+        if inference_type == 'fp16':
+            ep_type_params = {
+                'trt_fp16_enable': True,
+            }
+        elif inference_type == 'int8':
+            ep_type_params = {
+                'trt_fp16_enable': True,
+                'trt_int8_enable': True,
+                'trt_int8_calibration_table_name': 'calibration.flatbuffers',
+            }
+        else:
+            raise ValueError(f'Unsupported inference type for TensorRT: {inference_type}')
+        providers = [
+            (
+                'TensorrtExecutionProvider',
+                {
+                    'trt_engine_cache_enable': True,
+                    'trt_engine_cache_path': str(model_path.parent),
+                    'trt_op_types_to_exclude': 'NonMaxSuppression,NonZero,RoiAlign',
+                } | ep_type_params,
+            )
+        ]
+        if 'CUDAExecutionProvider' in available_providers:
+            providers.append('CUDAExecutionProvider')
+        providers.append('CPUExecutionProvider')
+        return providers
+
+    if requested and requested != 'cpu':
+        raise ValueError(f'Unsupported ONNX device: {device_arg}. Use cpu, cuda, cuda:0, or tensorrt.')
+
+    if device_arg is None and 'CUDAExecutionProvider' in available_providers:
+        return ['CUDAExecutionProvider', 'CPUExecutionProvider']
+    return ['CPUExecutionProvider']
 
 
 def build_transform(image_size: Sequence[int], normalize: bool) -> T.Compose:
@@ -925,6 +981,109 @@ class InferenceModel(nn.Module):
         )
 
 
+class OnnxInferenceModel:
+    def __init__(
+        self,
+        model_path: Path,
+        device_arg: str | None,
+        inference_type: str,
+        mask_resize_origin: str = 'topleft',
+    ):
+        try:
+            import onnxruntime as ort
+        except ImportError as exc:
+            raise ImportError('onnxruntime is required for ONNX inference.') from exc
+
+        providers = build_onnx_providers(device_arg, model_path, inference_type)
+        session_options = ort.SessionOptions()
+        self.session = ort.InferenceSession(
+            str(model_path),
+            sess_options=session_options,
+            providers=providers,
+        )
+        self.input_names = {inp.name for inp in self.session.get_inputs()}
+        self.output_names = [out.name for out in self.session.get_outputs()]
+        self.mask_resize_origin = mask_resize_origin
+        self.providers = self.session.get_providers()
+        image_input = self.session.get_inputs()[0]
+        image_shape = image_input.shape
+        self.image_size = tuple(int(v) for v in image_shape[2:4]) if len(image_shape) >= 4 and all(isinstance(v, int) for v in image_shape[2:4]) else None
+
+    def _decode_label_xyxy_score(
+        self,
+        label_xyxy_score: np.ndarray,
+        orig_target_sizes: torch.Tensor,
+    ) -> List[Dict[str, torch.Tensor]]:
+        batch_results: List[Dict[str, torch.Tensor]] = []
+        for batch_idx in range(label_xyxy_score.shape[0]):
+            batch_pred = label_xyxy_score[batch_idx]
+            boxes = torch.from_numpy(batch_pred[:, 1:5].astype(np.float32, copy=False))
+            if 'orig_target_sizes' not in self.input_names:
+                orig_w = float(orig_target_sizes[batch_idx, 0].item())
+                orig_h = float(orig_target_sizes[batch_idx, 1].item())
+                boxes[:, 0::2] *= orig_w
+                boxes[:, 1::2] *= orig_h
+            batch_results.append(
+                {
+                    'labels': torch.from_numpy(batch_pred[:, 0].astype(np.int64, copy=False)),
+                    'boxes': boxes,
+                    'scores': torch.from_numpy(batch_pred[:, 5].astype(np.float32, copy=False)),
+                }
+            )
+        return batch_results
+
+    def _resize_mask_batch(
+        self,
+        masks: np.ndarray,
+        orig_target_sizes: torch.Tensor,
+    ) -> List[torch.Tensor]:
+        resized_batches: List[torch.Tensor] = []
+        for batch_idx in range(masks.shape[0]):
+            batch_masks = torch.from_numpy(masks[batch_idx]).to(dtype=torch.float32)
+            batch_masks = resize_masks(
+                batch_masks.unsqueeze(1),
+                size=tuple(int(v) for v in orig_target_sizes[batch_idx, [1, 0]].tolist()),
+                mode='bilinear',
+                origin=self.mask_resize_origin,
+            )
+            resized_batches.append(batch_masks)
+        return resized_batches
+
+    @torch.inference_mode()
+    def __call__(
+        self,
+        image_tensor: torch.Tensor,
+        orig_target_sizes: torch.Tensor,
+        return_masks: bool = False,
+        return_contours: bool = False,
+    ):
+        input_feed = {'images': image_tensor.detach().cpu().numpy().astype(np.float32, copy=False)}
+        if 'orig_target_sizes' in self.input_names:
+            input_feed['orig_target_sizes'] = orig_target_sizes.detach().cpu().numpy().astype(np.float32, copy=False)
+
+        output_values = self.session.run(self.output_names, input_feed)
+        outputs = dict(zip(self.output_names, output_values))
+
+        if 'label_xyxy_score' not in outputs:
+            raise KeyError('ONNX model output `label_xyxy_score` is required.')
+
+        results = self._decode_label_xyxy_score(outputs['label_xyxy_score'], orig_target_sizes)
+
+        if return_masks:
+            if 'masks' not in outputs:
+                raise RuntimeError('ONNX model does not provide `masks`, but --enable-masks was requested.')
+            for result, masks in zip(results, self._resize_mask_batch(outputs['masks'], orig_target_sizes)):
+                result['masks'] = masks
+
+        if return_contours:
+            if 'contours' not in outputs:
+                raise RuntimeError('ONNX model does not provide `contours`, but --enable-contours was requested.')
+            for result, contours in zip(results, self._resize_mask_batch(outputs['contours'], orig_target_sizes)):
+                result['contours'] = contours
+
+        return results
+
+
 def save_predictions_json(output_dir: Path, image_path: Path, records: List[Dict[str, object]]) -> None:
     pred_dir = output_dir / 'predictions'
     pred_dir.mkdir(parents=True, exist_ok=True)
@@ -941,11 +1100,12 @@ def process_images(args) -> None:
     resume_path = Path(args.resume)
     images_dir = Path(args.images_dir)
     output_dir = Path(args.output_dir)
+    use_onnx = is_onnx_model(resume_path)
 
     if not config_path.exists():
         raise FileNotFoundError(f'Config file not found: {config_path}')
     if not resume_path.exists():
-        raise FileNotFoundError(f'Checkpoint file not found: {resume_path}')
+        raise FileNotFoundError(f'Model file not found: {resume_path}')
     if not images_dir.exists() or not images_dir.is_dir():
         raise FileNotFoundError(f'Image directory not found: {images_dir}')
 
@@ -955,18 +1115,31 @@ def process_images(args) -> None:
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    cfg = YAMLConfig(str(config_path), resume=str(resume_path))
-    if 'HGNetv2' in cfg.yaml_cfg:
-        cfg.yaml_cfg['HGNetv2']['pretrained'] = False
-    if 'DINOv3STAs' in cfg.yaml_cfg:
-        cfg.yaml_cfg['DINOv3STAs']['weights_path'] = None
+    if use_onnx:
+        yaml_cfg = load_config(str(config_path))
+        model = OnnxInferenceModel(
+            resume_path,
+            args.device,
+            args.inference_type,
+            mask_resize_origin=args.mask_resize_origin,
+        )
+        image_size = model.image_size or tuple(yaml_cfg['eval_spatial_size'])
+        normalize = bool(yaml_cfg.get('DINOv3STAs', False))
+    else:
+        if (args.device or '').lower() == 'tensorrt':
+            raise ValueError('TensorRT inference is only supported when --resume points to an ONNX model.')
+        cfg = YAMLConfig(str(config_path), resume=str(resume_path))
+        if 'HGNetv2' in cfg.yaml_cfg:
+            cfg.yaml_cfg['HGNetv2']['pretrained'] = False
+        if 'DINOv3STAs' in cfg.yaml_cfg:
+            cfg.yaml_cfg['DINOv3STAs']['weights_path'] = None
 
-    state_dict = load_checkpoint_state(resume_path)
-    device = resolve_device(args.device)
-    model = InferenceModel(cfg, state_dict, device, mask_resize_origin=args.mask_resize_origin)
+        state_dict = load_checkpoint_state(resume_path)
+        device = resolve_device(args.device)
+        model = InferenceModel(cfg, state_dict, device, mask_resize_origin=args.mask_resize_origin)
+        image_size = cfg.yaml_cfg['eval_spatial_size']
+        normalize = bool(cfg.yaml_cfg.get('DINOv3STAs', False))
 
-    image_size = cfg.yaml_cfg['eval_spatial_size']
-    normalize = bool(cfg.yaml_cfg.get('DINOv3STAs', False))
     transform = build_transform(image_size, normalize)
 
     object_score_threshold = args.object_score_threshold if args.object_score_threshold is not None else args.score_threshold
@@ -975,7 +1148,11 @@ def process_images(args) -> None:
     disable_render_classids = set(args.disable_render_classids)
 
     print(f'Processing {len(image_paths)} images from {images_dir}')
-    print(f'Using checkpoint: {resume_path}')
+    print(f'Using model: {resume_path}')
+    if use_onnx:
+        print(f'ONNX providers: {model.providers}')
+    else:
+        print(f'Device: {device}')
     print(f'Output directory: {output_dir}')
     print(f'Mask resize origin: {args.mask_resize_origin}')
     print(f'Enable masks: {args.enable_masks}')
@@ -990,7 +1167,9 @@ def process_images(args) -> None:
         image = Image.open(image_path).convert('RGB')
         orig_w, orig_h = image.size
         orig_target_sizes = torch.tensor([[orig_w, orig_h]], dtype=torch.float32)
-        image_tensor = transform(image).unsqueeze(0).to(device)
+        image_tensor = transform(image).unsqueeze(0)
+        if not use_onnx:
+            image_tensor = image_tensor.to(device)
 
         results = model(
             image_tensor,
@@ -1075,6 +1254,7 @@ def parse_args():
     parser.add_argument('-i', '--images_dir', type=str, required=True)
     parser.add_argument('-o', '--output_dir', type=str, required=True)
     parser.add_argument('-d', '--device', type=str, default=None)
+    parser.add_argument('--inference_type', type=str, choices=['fp16', 'int8'], default='fp16')
     parser.add_argument('--score_threshold', type=float, default=0.35)
     parser.add_argument('--object_score_threshold', '--object_socre_threshold', dest='object_score_threshold', type=float, default=None)
     parser.add_argument('--attribute_score_threshold', '--attribute_socre_threshold', dest='attribute_score_threshold', type=float, default=None)

--- a/engine/deim/deim.py
+++ b/engine/deim/deim.py
@@ -23,10 +23,15 @@ class DEIM(nn.Module):
         self.decoder = decoder
         self.encoder = encoder
 
-    def forward(self, x, targets=None):
+    def forward(self, x, targets=None, return_masks=True, return_contours=False):
         x = self.backbone(x)
         x = self.encoder(x)
-        x = self.decoder(x, targets)
+        x = self.decoder(
+            x,
+            targets,
+            return_masks=return_masks,
+            return_contours=return_contours,
+        )
 
         return x
 

--- a/engine/deim/deim_criterion.py
+++ b/engine/deim/deim_criterion.py
@@ -25,7 +25,7 @@ from ..core import register
 class DEIMCriterion(nn.Module):
     """ This class computes the loss for DEIM.
     """
-    __share__ = ['num_classes', 'mask_category_ids', 'mask_resize_origin']
+    __share__ = ['num_classes', 'mask_category_ids', 'mask_target_class_ids', 'mask_resize_origin']
     __inject__ = ['matcher', ]
 
     def __init__(self, \
@@ -37,6 +37,7 @@ class DEIMCriterion(nn.Module):
         num_classes=80,
         reg_max=32,
         mask_category_ids=None,
+        mask_target_class_ids=None,
         mask_resize_origin='center',
         boxes_weight_format=None,
         share_matched_indices=False,
@@ -71,6 +72,9 @@ class DEIMCriterion(nn.Module):
         self.own_targets, self.own_targets_dn = None, None
         self.reg_max = reg_max
         self.mask_category_ids = [] if mask_category_ids is None else list(mask_category_ids)
+        if mask_target_class_ids is None:
+            mask_target_class_ids = self.mask_category_ids
+        self.mask_target_class_ids = [] if mask_target_class_ids is None else list(mask_target_class_ids)
         self.mask_resize_origin = mask_resize_origin
         self.num_pos, self.num_neg = None, None
         self.mal_alpha = mal_alpha
@@ -93,6 +97,7 @@ class DEIMCriterion(nn.Module):
             'gamma': self.gamma,
             'reg_max': self.reg_max,
             'mask_category_ids': copy.deepcopy(self.mask_category_ids),
+            'mask_target_class_ids': copy.deepcopy(self.mask_target_class_ids),
             'mask_resize_origin': self.mask_resize_origin,
             'mal_alpha': self.mal_alpha,
             'use_uni_set': self.use_uni_set,
@@ -116,6 +121,7 @@ class DEIMCriterion(nn.Module):
         self.gamma = state.get('gamma', self.gamma)
         self.reg_max = state.get('reg_max', self.reg_max)
         self.mask_category_ids = copy.deepcopy(state.get('mask_category_ids', self.mask_category_ids))
+        self.mask_target_class_ids = copy.deepcopy(state.get('mask_target_class_ids', self.mask_target_class_ids))
         self.mask_resize_origin = state.get('mask_resize_origin', self.mask_resize_origin)
         self.mal_alpha = state.get('mal_alpha', self.mal_alpha)
         self.use_uni_set = state.get('use_uni_set', self.use_uni_set)
@@ -276,10 +282,10 @@ class DEIMCriterion(nn.Module):
         return losses
 
     def loss_masks(self, outputs, targets, indices, num_boxes):
-        if 'pred_masks' not in outputs:
+        if 'pred_masks' not in outputs and 'mask_embed' not in outputs:
             return {}
 
-        zero = outputs['pred_masks'].sum() * 0
+        zero = self._get_mask_zero(outputs)
 
         src_masks_list = []
         src_contours_list = []
@@ -291,28 +297,52 @@ class DEIMCriterion(nn.Module):
                 continue
             if 'masks' not in target or 'mask_valid' not in target:
                 raise KeyError('Body-only mask supervision requires `masks` and `mask_valid` in targets.')
-            valid = target['mask_valid'][matched_target_idx]
+            valid = self._select_valid_mask_matches(target, matched_target_idx)
             if valid.numel() == 0 or not valid.any():
                 continue
-            src_masks_list.append(outputs['pred_masks'][batch_idx, matched_pred_idx[valid]])
-            if self.use_contour_detection and 'pred_mask_contours' in outputs:
-                src_contours_list.append(outputs['pred_mask_contours'][batch_idx, matched_pred_idx[valid]])
-            if self.use_distance_transform and 'pred_mask_distances' in outputs:
-                src_distances_list.append(outputs['pred_mask_distances'][batch_idx, matched_pred_idx[valid]])
+            selected_pred_idx = matched_pred_idx[valid]
+            if 'pred_masks' in outputs:
+                src_masks_list.append(outputs['pred_masks'][batch_idx, selected_pred_idx])
+            else:
+                src_masks_list.append(
+                    self._compute_sparse_mask_logits(
+                        outputs['mask_embed'],
+                        outputs['mask_features'],
+                        batch_idx,
+                        selected_pred_idx,
+                    )
+                )
+            if self.use_contour_detection:
+                if 'pred_mask_contours' in outputs:
+                    src_contours_list.append(outputs['pred_mask_contours'][batch_idx, selected_pred_idx])
+                elif 'pred_mask_contour_embeds' in outputs and 'pred_mask_contour_features' in outputs:
+                    src_contours_list.append(
+                        self._compute_sparse_mask_logits(
+                            outputs['pred_mask_contour_embeds'],
+                            outputs['pred_mask_contour_features'],
+                            batch_idx,
+                            selected_pred_idx,
+                        )
+                    )
+            if self.use_distance_transform:
+                if 'pred_mask_distances' in outputs:
+                    src_distances_list.append(outputs['pred_mask_distances'][batch_idx, selected_pred_idx])
+                elif 'pred_mask_distance_embeds' in outputs and 'pred_mask_distance_features' in outputs:
+                    src_distances_list.append(
+                        self._compute_sparse_mask_logits(
+                            outputs['pred_mask_distance_embeds'],
+                            outputs['pred_mask_distance_features'],
+                            batch_idx,
+                            selected_pred_idx,
+                        )
+                    )
             target_masks.append(
                 target['masks'][matched_target_idx[valid]]
             )
             valid_masks.append(valid.sum())
 
         if not src_masks_list:
-            losses = {'loss_mask_bce': zero, 'loss_mask_dice': zero}
-            if self.use_boundary_aware_loss:
-                losses['loss_mask_boundary'] = zero
-            if self.use_contour_detection:
-                losses['loss_mask_contour'] = zero
-            if self.use_distance_transform:
-                losses['loss_mask_distance'] = zero
-            return losses
+            return self._build_zero_mask_losses(zero)
 
         src_masks = torch.cat(src_masks_list, dim=0)
         target_masks = torch.cat(target_masks, dim=0)
@@ -371,6 +401,47 @@ class DEIMCriterion(nn.Module):
             losses['loss_mask_distance'] = loss_mask_distance
 
         return losses
+
+    def _get_mask_zero(self, outputs):
+        for key in (
+            'pred_masks',
+            'mask_embed',
+            'mask_features',
+            'pred_mask_contours',
+            'pred_mask_contour_embeds',
+            'pred_mask_distances',
+            'pred_mask_distance_embeds',
+        ):
+            value = outputs.get(key)
+            if torch.is_tensor(value):
+                return value.sum() * 0
+        raise KeyError('Mask loss requested but no tensor outputs are available to build a zero scalar.')
+
+    def _build_zero_mask_losses(self, zero):
+        losses = {'loss_mask_bce': zero, 'loss_mask_dice': zero}
+        if self.use_boundary_aware_loss:
+            losses['loss_mask_boundary'] = zero
+        if self.use_contour_detection:
+            losses['loss_mask_contour'] = zero
+        if self.use_distance_transform:
+            losses['loss_mask_distance'] = zero
+        return losses
+
+    def _select_valid_mask_matches(self, target, matched_target_idx):
+        valid = target['mask_valid'][matched_target_idx]
+        if self.mask_target_class_ids:
+            labels = target['labels'][matched_target_idx]
+            class_mask = torch.stack(
+                [labels == int(class_id) for class_id in self.mask_target_class_ids],
+                dim=0,
+            ).any(dim=0)
+            valid = valid & class_mask
+        return valid
+
+    def _compute_sparse_mask_logits(self, embeds, features, batch_idx, selected_pred_idx):
+        selected_embeds = embeds[batch_idx, selected_pred_idx]
+        feature_map = features[batch_idx]
+        return torch.einsum('qc,chw->qhw', selected_embeds, feature_map)
 
     def _build_boundary_weight_map(
         self,

--- a/engine/deim/deim_decoder.py
+++ b/engine/deim/deim_decoder.py
@@ -287,6 +287,8 @@ class DEIMTransformer(nn.Module):
                  share_bbox_head=False,
                  share_score_head=False,
                  mask_compute_mode='full',
+                 mask_embed_head_hidden_dim=256,
+                 mask_embed_head_num_layers=3,
                  ):
         super().__init__()
         assert len(feat_channels) <= num_levels
@@ -314,6 +316,12 @@ class DEIMTransformer(nn.Module):
         if mask_compute_mode not in ('full', 'lazy'):
             raise ValueError(f'Unsupported mask_compute_mode={mask_compute_mode}')
         self.mask_compute_mode = mask_compute_mode
+        if int(mask_embed_head_hidden_dim) <= 0:
+            raise ValueError(f'Unsupported mask_embed_head_hidden_dim={mask_embed_head_hidden_dim}')
+        if int(mask_embed_head_num_layers) < 2:
+            raise ValueError(f'Unsupported mask_embed_head_num_layers={mask_embed_head_num_layers}')
+        self.mask_embed_head_hidden_dim = int(mask_embed_head_hidden_dim)
+        self.mask_embed_head_num_layers = int(mask_embed_head_num_layers)
 
         assert query_select_method in ('default', 'one2many', 'agnostic'), ''
         assert cross_attn_method in ('default', 'discrete'), ''
@@ -356,7 +364,13 @@ class DEIMTransformer(nn.Module):
         self.enc_bbox_head = MLP(hidden_dim, hidden_dim, 4, 3, act=mlp_act)
 
         self.query_pos_head = MLP(4, hidden_dim, hidden_dim, 3, act=mlp_act)
-        self.mask_embed_head = MLP(hidden_dim, hidden_dim, hidden_dim, 3, act=mlp_act)
+        self.mask_embed_head = MLP(
+            hidden_dim,
+            self.mask_embed_head_hidden_dim,
+            hidden_dim,
+            self.mask_embed_head_num_layers,
+            act=mlp_act,
+        )
         self.mask_feature_head = nn.Sequential(OrderedDict([
             ('conv', nn.Conv2d(hidden_dim, hidden_dim, 3, padding=1, bias=False)),
             ('norm', nn.BatchNorm2d(hidden_dim)),
@@ -425,6 +439,8 @@ class DEIMTransformer(nn.Module):
             'reg_max': self.reg_max,
             'mask_feature_level': self.mask_feature_level,
             'mask_compute_mode': self.mask_compute_mode,
+            'mask_embed_head_hidden_dim': self.mask_embed_head_hidden_dim,
+            'mask_embed_head_num_layers': self.mask_embed_head_num_layers,
             'use_contour_aux_head': self.use_contour_aux_head,
             'use_distance_aux_head': self.use_distance_aux_head,
             'aux_mask_feature_level': self.aux_mask_feature_level,
@@ -453,6 +469,8 @@ class DEIMTransformer(nn.Module):
         self.reg_max = state.get('reg_max', self.reg_max)
         self.mask_feature_level = state.get('mask_feature_level', self.mask_feature_level)
         self.mask_compute_mode = state.get('mask_compute_mode', self.mask_compute_mode)
+        self.mask_embed_head_hidden_dim = state.get('mask_embed_head_hidden_dim', self.mask_embed_head_hidden_dim)
+        self.mask_embed_head_num_layers = state.get('mask_embed_head_num_layers', self.mask_embed_head_num_layers)
         self.use_contour_aux_head = state.get('use_contour_aux_head', self.use_contour_aux_head)
         self.use_distance_aux_head = state.get('use_distance_aux_head', self.use_distance_aux_head)
         self.aux_mask_feature_level = state.get('aux_mask_feature_level', self.aux_mask_feature_level)
@@ -484,20 +502,21 @@ class DEIMTransformer(nn.Module):
         init.xavier_uniform_(self.query_pos_head.layers[0].weight)
         init.xavier_uniform_(self.query_pos_head.layers[1].weight)
         init.xavier_uniform_(self.query_pos_head.layers[-1].weight)
-        init.xavier_uniform_(self.mask_embed_head.layers[0].weight)
-        init.xavier_uniform_(self.mask_embed_head.layers[1].weight)
-        init.xavier_uniform_(self.mask_embed_head.layers[-1].weight)
+        self._init_mlp(self.mask_embed_head)
         if self.use_contour_aux_head:
-            init.xavier_uniform_(self.contour_embed_head.layers[0].weight)
-            init.xavier_uniform_(self.contour_embed_head.layers[1].weight)
-            init.xavier_uniform_(self.contour_embed_head.layers[-1].weight)
+            self._init_mlp(self.contour_embed_head)
         if self.use_distance_aux_head:
-            init.xavier_uniform_(self.distance_embed_head.layers[0].weight)
-            init.xavier_uniform_(self.distance_embed_head.layers[1].weight)
-            init.xavier_uniform_(self.distance_embed_head.layers[-1].weight)
+            self._init_mlp(self.distance_embed_head)
         for m, in_channels in zip(self.input_proj, feat_channels):
             if in_channels != self.hidden_dim:
                 init.xavier_uniform_(m[0].weight)
+
+    @staticmethod
+    def _init_mlp(mlp: MLP) -> None:
+        for layer in mlp.layers:
+            init.xavier_uniform_(layer.weight)
+            if layer.bias is not None:
+                init.constant_(layer.bias, 0)
 
     def _get_mask_logits(self, query_features: torch.Tensor, mask_features: torch.Tensor) -> torch.Tensor:
         mask_embed = self._get_mask_embed(query_features)
@@ -548,15 +567,20 @@ class DEIMTransformer(nn.Module):
             f'Received {len(feats)} feature levels, expected index range [0, {upper_bound}].'
         )
 
-    def _maybe_get_aux_mask_features(self, feats: List[torch.Tensor]) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    def _maybe_get_aux_mask_features(
+        self,
+        feats: List[torch.Tensor],
+        need_contour_features: bool,
+        need_distance_features: bool,
+    ) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         contour_features = None
         distance_features = None
-        if self.use_contour_aux_head or self.use_distance_aux_head:
+        if need_contour_features or need_distance_features:
             self._validate_feature_level(self.aux_mask_feature_level, feats, 'aux_mask_feature_level')
 
-        if self.use_contour_aux_head:
+        if need_contour_features:
             contour_features = self.contour_feature_head(feats[self.aux_mask_feature_level])
-        if self.use_distance_aux_head:
+        if need_distance_features:
             distance_features = self.distance_feature_head(feats[self.aux_mask_feature_level])
         return contour_features, distance_features
 
@@ -713,7 +737,8 @@ class DEIMTransformer(nn.Module):
         # input projection and embedding
         memory, spatial_shapes = self._get_encoder_input(feats)
         need_mask_features = self.training or return_masks
-        need_contour_features = self.training or return_contours
+        need_contour_features = self.use_contour_aux_head and (self.training or return_contours)
+        need_distance_features = self.use_distance_aux_head and self.training
 
         mask_features = None
         if need_mask_features:
@@ -721,8 +746,12 @@ class DEIMTransformer(nn.Module):
             mask_features = self.mask_feature_head(feats[self.mask_feature_level])
 
         contour_features, distance_features = None, None
-        if self.training or need_contour_features:
-            contour_features, distance_features = self._maybe_get_aux_mask_features(feats)
+        if need_contour_features or need_distance_features:
+            contour_features, distance_features = self._maybe_get_aux_mask_features(
+                feats,
+                need_contour_features=need_contour_features,
+                need_distance_features=need_distance_features,
+            )
 
         # prepare denoising training
         if self.training and self.num_denoising > 0:

--- a/engine/deim/deim_decoder.py
+++ b/engine/deim/deim_decoder.py
@@ -146,6 +146,12 @@ class TransformerDecoder(nn.Module):
         self.layers = self.layers[:self.eval_idx + 1]
         self.lqe_layers = nn.ModuleList([nn.Identity()] * (self.eval_idx) + [self.lqe_layers[self.eval_idx]])
 
+    @staticmethod
+    def _finalize_decoder_outputs(outputs: list[torch.Tensor]) -> torch.Tensor:
+        if torch.onnx.is_in_onnx_export() and len(outputs) == 1:
+            return outputs[0]
+        return torch.stack(outputs)
+
     def forward(self,
                 target,
                 ref_points_unact,
@@ -227,13 +233,24 @@ class TransformerDecoder(nn.Module):
             ref_points_detach = inter_ref_bbox.detach()
             output_detach = output.detach()
 
-        return torch.stack(dec_out_bboxes), torch.stack(dec_out_logits), \
-               torch.stack(dec_out_pred_corners), torch.stack(dec_out_refs), pre_bboxes, pre_scores, output
+        return (
+            self._finalize_decoder_outputs(dec_out_bboxes),
+            self._finalize_decoder_outputs(dec_out_logits),
+            self._finalize_decoder_outputs(dec_out_pred_corners),
+            self._finalize_decoder_outputs(dec_out_refs),
+            pre_bboxes,
+            pre_scores,
+            output,
+        )
 
 
 @register()
 class DEIMTransformer(nn.Module):
     __share__ = ['num_classes', 'eval_spatial_size']
+
+    @staticmethod
+    def _last_decoder_output(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor[-1] if tensor.dim() > 3 else tensor
 
     def __init__(self,
                  num_classes=80,
@@ -720,8 +737,10 @@ class DEIMTransformer(nn.Module):
             _, out_queries = torch.split(out_queries, dn_meta['dn_num_split'], dim=1)
 
         if self.training:
-            out = {'pred_logits': out_logits[-1], 'pred_boxes': out_bboxes[-1], 'pred_corners': out_corners[-1],
-                   'ref_points': out_refs[-1], 'up': self.up, 'reg_scale': self.reg_scale,
+            out = {'pred_logits': self._last_decoder_output(out_logits),
+                   'pred_boxes': self._last_decoder_output(out_bboxes),
+                   'pred_corners': self._last_decoder_output(out_corners),
+                   'ref_points': self._last_decoder_output(out_refs), 'up': self.up, 'reg_scale': self.reg_scale,
                    'pred_masks': self._get_mask_logits(out_queries, mask_features)}
             if self.use_contour_aux_head and contour_features is not None:
                 out['pred_mask_contours'] = self._get_aux_mask_logits(
@@ -736,7 +755,10 @@ class DEIMTransformer(nn.Module):
                     self.distance_embed_head,
                 )
         else:
-            out = {'pred_logits': out_logits[-1], 'pred_boxes': out_bboxes[-1]}
+            out = {
+                'pred_logits': self._last_decoder_output(out_logits),
+                'pred_boxes': self._last_decoder_output(out_bboxes),
+            }
             if return_masks:
                 out['pred_masks'] = self._get_mask_logits(out_queries, mask_features)
             if return_contours:

--- a/engine/deim/deim_decoder.py
+++ b/engine/deim/deim_decoder.py
@@ -501,9 +501,6 @@ class DEIMTransformer(nn.Module):
     def _maybe_get_aux_mask_features(self, feats: List[torch.Tensor]) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         contour_features = None
         distance_features = None
-        if not self.training:
-            return contour_features, distance_features
-
         if self.use_contour_aux_head or self.use_distance_aux_head:
             self._validate_feature_level(self.aux_mask_feature_level, feats, 'aux_mask_feature_level')
 
@@ -662,12 +659,20 @@ class DEIMTransformer(nn.Module):
 
         return topk_memory, topk_logits, topk_anchors
 
-    def forward(self, feats, targets=None):
+    def forward(self, feats, targets=None, return_masks=True, return_contours=False):
         # input projection and embedding
-        self._validate_feature_level(self.mask_feature_level, feats, 'mask_feature_level')
         memory, spatial_shapes = self._get_encoder_input(feats)
-        mask_features = self.mask_feature_head(feats[self.mask_feature_level])
-        contour_features, distance_features = self._maybe_get_aux_mask_features(feats)
+        need_mask_features = self.training or return_masks
+        need_contour_features = self.training or return_contours
+
+        mask_features = None
+        if need_mask_features:
+            self._validate_feature_level(self.mask_feature_level, feats, 'mask_feature_level')
+            mask_features = self.mask_feature_head(feats[self.mask_feature_level])
+
+        contour_features, distance_features = None, None
+        if self.training or need_contour_features:
+            contour_features, distance_features = self._maybe_get_aux_mask_features(feats)
 
         # prepare denoising training
         if self.training and self.num_denoising > 0:
@@ -731,8 +736,19 @@ class DEIMTransformer(nn.Module):
                     self.distance_embed_head,
                 )
         else:
-            out = {'pred_logits': out_logits[-1], 'pred_boxes': out_bboxes[-1],
-                   'pred_masks': self._get_mask_logits(out_queries, mask_features)}
+            out = {'pred_logits': out_logits[-1], 'pred_boxes': out_bboxes[-1]}
+            if return_masks:
+                out['pred_masks'] = self._get_mask_logits(out_queries, mask_features)
+            if return_contours:
+                if not self.use_contour_aux_head:
+                    raise RuntimeError('Contour output requested, but the decoder was not built with contour head support.')
+                if contour_features is None:
+                    raise RuntimeError('Contour output requested, but contour features are unavailable.')
+                out['pred_mask_contours'] = self._get_aux_mask_logits(
+                    out_queries,
+                    contour_features,
+                    self.contour_embed_head,
+                )
 
         if self.training and self.aux_loss:
             out['aux_outputs'] = self._set_aux_loss2(out_logits[:-1], out_bboxes[:-1], out_corners[:-1], out_refs[:-1],

--- a/engine/deim/deim_decoder.py
+++ b/engine/deim/deim_decoder.py
@@ -246,7 +246,7 @@ class TransformerDecoder(nn.Module):
 
 @register()
 class DEIMTransformer(nn.Module):
-    __share__ = ['num_classes', 'eval_spatial_size']
+    __share__ = ['num_classes', 'eval_spatial_size', 'mask_compute_mode']
 
     @staticmethod
     def _last_decoder_output(tensor: torch.Tensor) -> torch.Tensor:
@@ -286,6 +286,7 @@ class DEIMTransformer(nn.Module):
                  use_gateway=True,
                  share_bbox_head=False,
                  share_score_head=False,
+                 mask_compute_mode='full',
                  ):
         super().__init__()
         assert len(feat_channels) <= num_levels
@@ -310,6 +311,9 @@ class DEIMTransformer(nn.Module):
         self.use_contour_aux_head = use_contour_aux_head
         self.use_distance_aux_head = use_distance_aux_head
         self.aux_mask_feature_level = mask_feature_level if aux_mask_feature_level is None else aux_mask_feature_level
+        if mask_compute_mode not in ('full', 'lazy'):
+            raise ValueError(f'Unsupported mask_compute_mode={mask_compute_mode}')
+        self.mask_compute_mode = mask_compute_mode
 
         assert query_select_method in ('default', 'one2many', 'agnostic'), ''
         assert cross_attn_method in ('default', 'discrete'), ''
@@ -420,6 +424,7 @@ class DEIMTransformer(nn.Module):
             'aux_loss': self.aux_loss,
             'reg_max': self.reg_max,
             'mask_feature_level': self.mask_feature_level,
+            'mask_compute_mode': self.mask_compute_mode,
             'use_contour_aux_head': self.use_contour_aux_head,
             'use_distance_aux_head': self.use_distance_aux_head,
             'aux_mask_feature_level': self.aux_mask_feature_level,
@@ -447,6 +452,7 @@ class DEIMTransformer(nn.Module):
         self.aux_loss = state.get('aux_loss', self.aux_loss)
         self.reg_max = state.get('reg_max', self.reg_max)
         self.mask_feature_level = state.get('mask_feature_level', self.mask_feature_level)
+        self.mask_compute_mode = state.get('mask_compute_mode', self.mask_compute_mode)
         self.use_contour_aux_head = state.get('use_contour_aux_head', self.use_contour_aux_head)
         self.use_distance_aux_head = state.get('use_distance_aux_head', self.use_distance_aux_head)
         self.aux_mask_feature_level = state.get('aux_mask_feature_level', self.aux_mask_feature_level)
@@ -494,7 +500,13 @@ class DEIMTransformer(nn.Module):
                 init.xavier_uniform_(m[0].weight)
 
     def _get_mask_logits(self, query_features: torch.Tensor, mask_features: torch.Tensor) -> torch.Tensor:
-        mask_embed = self.mask_embed_head(query_features)
+        mask_embed = self._get_mask_embed(query_features)
+        return self._mask_logits_from_embeddings(mask_embed, mask_features)
+
+    def _get_mask_embed(self, query_features: torch.Tensor) -> torch.Tensor:
+        return self.mask_embed_head(query_features)
+
+    def _mask_logits_from_embeddings(self, mask_embed: torch.Tensor, mask_features: torch.Tensor) -> torch.Tensor:
         return torch.einsum('bqc,bchw->bqhw', mask_embed, mask_features)
 
     def _get_aux_mask_logits(
@@ -504,7 +516,28 @@ class DEIMTransformer(nn.Module):
         embed_head: MLP,
     ) -> torch.Tensor:
         mask_embed = embed_head(query_features)
-        return torch.einsum('bqc,bchw->bqhw', mask_embed, mask_features)
+        return self._mask_logits_from_embeddings(mask_embed, mask_features)
+
+    def _build_lazy_mask_outputs(
+        self,
+        out_queries: torch.Tensor,
+        mask_features: Optional[torch.Tensor],
+        contour_features: Optional[torch.Tensor],
+        distance_features: Optional[torch.Tensor],
+        return_masks: bool,
+        return_contours: bool,
+    ) -> dict[str, torch.Tensor]:
+        lazy_outputs: dict[str, torch.Tensor] = {}
+        if mask_features is not None:
+            lazy_outputs['mask_embed'] = self._get_mask_embed(out_queries)
+            lazy_outputs['mask_features'] = mask_features
+        if contour_features is not None and (self.training or return_contours):
+            lazy_outputs['pred_mask_contour_embeds'] = self.contour_embed_head(out_queries)
+            lazy_outputs['pred_mask_contour_features'] = contour_features
+        if distance_features is not None and self.training:
+            lazy_outputs['pred_mask_distance_embeds'] = self.distance_embed_head(out_queries)
+            lazy_outputs['pred_mask_distance_features'] = distance_features
+        return lazy_outputs
 
     def _validate_feature_level(self, feature_level: int, feats: List[torch.Tensor], feature_name: str) -> None:
         if 0 <= feature_level < len(feats):
@@ -737,40 +770,68 @@ class DEIMTransformer(nn.Module):
             _, out_queries = torch.split(out_queries, dn_meta['dn_num_split'], dim=1)
 
         if self.training:
-            out = {'pred_logits': self._last_decoder_output(out_logits),
-                   'pred_boxes': self._last_decoder_output(out_bboxes),
-                   'pred_corners': self._last_decoder_output(out_corners),
-                   'ref_points': self._last_decoder_output(out_refs), 'up': self.up, 'reg_scale': self.reg_scale,
-                   'pred_masks': self._get_mask_logits(out_queries, mask_features)}
-            if self.use_contour_aux_head and contour_features is not None:
-                out['pred_mask_contours'] = self._get_aux_mask_logits(
-                    out_queries,
-                    contour_features,
-                    self.contour_embed_head,
+            out = {
+                'pred_logits': self._last_decoder_output(out_logits),
+                'pred_boxes': self._last_decoder_output(out_bboxes),
+                'pred_corners': self._last_decoder_output(out_corners),
+                'ref_points': self._last_decoder_output(out_refs),
+                'up': self.up,
+                'reg_scale': self.reg_scale,
+            }
+            if self.mask_compute_mode == 'lazy':
+                out.update(
+                    self._build_lazy_mask_outputs(
+                        out_queries,
+                        mask_features,
+                        contour_features,
+                        distance_features,
+                        return_masks=True,
+                        return_contours=True,
+                    )
                 )
-            if self.use_distance_aux_head and distance_features is not None:
-                out['pred_mask_distances'] = self._get_aux_mask_logits(
-                    out_queries,
-                    distance_features,
-                    self.distance_embed_head,
-                )
+            else:
+                out['pred_masks'] = self._get_mask_logits(out_queries, mask_features)
+                if self.use_contour_aux_head and contour_features is not None:
+                    out['pred_mask_contours'] = self._get_aux_mask_logits(
+                        out_queries,
+                        contour_features,
+                        self.contour_embed_head,
+                    )
+                if self.use_distance_aux_head and distance_features is not None:
+                    out['pred_mask_distances'] = self._get_aux_mask_logits(
+                        out_queries,
+                        distance_features,
+                        self.distance_embed_head,
+                    )
         else:
             out = {
                 'pred_logits': self._last_decoder_output(out_logits),
                 'pred_boxes': self._last_decoder_output(out_bboxes),
             }
-            if return_masks:
-                out['pred_masks'] = self._get_mask_logits(out_queries, mask_features)
-            if return_contours:
-                if not self.use_contour_aux_head:
-                    raise RuntimeError('Contour output requested, but the decoder was not built with contour head support.')
-                if contour_features is None:
-                    raise RuntimeError('Contour output requested, but contour features are unavailable.')
-                out['pred_mask_contours'] = self._get_aux_mask_logits(
-                    out_queries,
-                    contour_features,
-                    self.contour_embed_head,
+            if self.mask_compute_mode == 'lazy':
+                out.update(
+                    self._build_lazy_mask_outputs(
+                        out_queries,
+                        mask_features,
+                        contour_features,
+                        distance_features,
+                        return_masks=return_masks,
+                        return_contours=return_contours,
+                    )
                 )
+            else:
+                if return_masks:
+                    out['pred_masks'] = self._get_mask_logits(out_queries, mask_features)
+                if return_contours:
+                    if not self.use_contour_aux_head:
+                        raise RuntimeError('Contour output requested, but the decoder was not built with contour head support.')
+                    if contour_features is None:
+                        raise RuntimeError('Contour output requested, but contour features are unavailable.')
+                    out['pred_mask_contours'] = self._get_aux_mask_logits(
+                        out_queries,
+                        contour_features,
+                        self.contour_embed_head,
+                    )
 
         if self.training and self.aux_loss:
             out['aux_outputs'] = self._set_aux_loss2(out_logits[:-1], out_bboxes[:-1], out_corners[:-1], out_refs[:-1],

--- a/engine/deim/postprocessor.py
+++ b/engine/deim/postprocessor.py
@@ -87,6 +87,15 @@ class PostProcessor(nn.Module):
         if predictions is None:
             return None
 
+        if orig_target_sizes is None:
+            gather_index = query_index[:, :, None, None].expand(
+                -1,
+                -1,
+                predictions.shape[-2],
+                predictions.shape[-1],
+            )
+            return predictions.gather(dim=1, index=gather_index).sigmoid()
+
         gathered = []
         for batch_idx in range(predictions.shape[0]):
             logits = predictions[batch_idx, query_index[batch_idx]].unsqueeze(1)

--- a/engine/deim/postprocessor.py
+++ b/engine/deim/postprocessor.py
@@ -78,10 +78,38 @@ class PostProcessor(nn.Module):
             origin=self.mask_resize_origin,
         )
 
+    def _gather_mask_like(
+        self,
+        predictions: torch.Tensor | None,
+        query_index: torch.Tensor,
+        orig_target_sizes: torch.Tensor | None,
+    ) -> torch.Tensor | list[torch.Tensor] | None:
+        if predictions is None:
+            return None
+
+        gathered = []
+        for batch_idx in range(predictions.shape[0]):
+            logits = predictions[batch_idx, query_index[batch_idx]].unsqueeze(1)
+            if orig_target_sizes is not None:
+                orig_w, orig_h = orig_target_sizes[batch_idx].tolist()
+                logits = self.resize_masks(logits, size=(int(orig_h), int(orig_w)))
+            gathered.append(logits.sigmoid())
+
+        if orig_target_sizes is not None:
+            return gathered
+        return torch.stack(gathered, dim=0)
+
     # def forward(self, outputs, orig_target_sizes):
-    def forward(self, outputs, orig_target_sizes: torch.Tensor=None):
+    def forward(
+        self,
+        outputs,
+        orig_target_sizes: torch.Tensor=None,
+        return_masks: bool=True,
+        return_contours: bool=False,
+    ):
         logits, boxes = outputs['pred_logits'], outputs['pred_boxes']
-        pred_masks = outputs.get('pred_masks')
+        pred_masks = outputs.get('pred_masks') if return_masks else None
+        pred_contours = outputs.get('pred_mask_contours') if return_contours else None
         bbox_pred = self.box_cxcywh_to_xyxy(boxes)
         if orig_target_sizes is not None:
             bbox_pred *= orig_target_sizes.repeat(1, 2).unsqueeze(1)
@@ -106,15 +134,32 @@ class PostProcessor(nn.Module):
                 query_index = torch.arange(scores.shape[1], device=logits.device).unsqueeze(0).expand(scores.shape[0], -1)
                 boxes = bbox_pred
 
+        gathered_masks = self._gather_mask_like(pred_masks, query_index, orig_target_sizes)
+        gathered_contours = self._gather_mask_like(pred_contours, query_index, orig_target_sizes)
+
         if self.deploy_mode:
+            if orig_target_sizes is not None and (gathered_masks is not None or gathered_contours is not None):
+                raise RuntimeError('Deploy mode does not support resized mask/contour outputs. Export without orig_target_sizes instead.')
+
+            deploy_labels = labels
+            deploy_scores = scores
+            if deploy_labels.dim() == 2:
+                deploy_labels = deploy_labels.unsqueeze(-1)
+            if deploy_scores.dim() == 2:
+                deploy_scores = deploy_scores.unsqueeze(-1)
+            label_xyxy_score = torch.cat([deploy_labels, boxes, deploy_scores], dim=2)
+
+            if gathered_masks is not None or gathered_contours is not None:
+                deploy_outputs = [label_xyxy_score]
+                if gathered_masks is not None:
+                    deploy_outputs.append(gathered_masks)
+                if gathered_contours is not None:
+                    deploy_outputs.append(gathered_contours)
+                return tuple(deploy_outputs)
+
             if orig_target_sizes is not None:
                 return labels, boxes, scores
-            else:
-                if labels.dim() == 2:
-                    labels = labels.unsqueeze(-1)
-                if scores.dim() == 2:
-                    scores = scores.unsqueeze(-1)
-                return torch.cat([labels, boxes, scores], dim=2)
+            return label_xyxy_score
 
         if self.remap_mscoco_category:
             from ..data.dataset import mscoco_label2category
@@ -129,12 +174,10 @@ class PostProcessor(nn.Module):
         results = []
         for batch_idx, (lab, box, sco) in enumerate(zip(labels, boxes, scores)):
             result = dict(labels=lab, boxes=box, scores=sco)
-            if pred_masks is not None:
-                mask_logits = pred_masks[batch_idx, query_index[batch_idx]].unsqueeze(1)
-                if orig_target_sizes is not None:
-                    orig_w, orig_h = orig_target_sizes[batch_idx].tolist()
-                    mask_logits = self.resize_masks(mask_logits, size=(int(orig_h), int(orig_w)))
-                result['masks'] = mask_logits.sigmoid()
+            if gathered_masks is not None:
+                result['masks'] = gathered_masks[batch_idx]
+            if gathered_contours is not None:
+                result['contours'] = gathered_contours[batch_idx]
             results.append(result)
 
         return results

--- a/engine/deim/postprocessor.py
+++ b/engine/deim/postprocessor.py
@@ -25,6 +25,7 @@ class PostProcessor(nn.Module):
         'num_classes',
         'use_focal_loss',
         'num_top_queries',
+        'k_max',
         'mask_target_class_ids',
         'remap_mscoco_category',
         'mask_resize_origin',
@@ -35,6 +36,7 @@ class PostProcessor(nn.Module):
         num_classes=80,
         use_focal_loss=True,
         num_top_queries=300,
+        k_max=0,
         mask_target_class_ids=None,
         remap_mscoco_category=False,
         mask_resize_origin='center',
@@ -43,6 +45,9 @@ class PostProcessor(nn.Module):
         self.use_focal_loss = use_focal_loss
         self.num_top_queries = num_top_queries
         self.num_classes = int(num_classes)
+        self.k_max = int(k_max)
+        if self.k_max < 0:
+            raise ValueError(f'Unsupported k_max={k_max}')
         self.mask_target_class_ids = [] if mask_target_class_ids is None else [int(x) for x in mask_target_class_ids]
         self.remap_mscoco_category = remap_mscoco_category
         self.deploy_mode = False
@@ -127,15 +132,66 @@ class PostProcessor(nn.Module):
         gather_index = query_index.unsqueeze(-1).expand(-1, -1, embeddings.shape[-1])
         return embeddings.gather(dim=1, index=gather_index)
 
+    def _score_tensor_for_mask_selection(self, scores: torch.Tensor) -> torch.Tensor:
+        return scores.squeeze(-1) if scores.dim() > 2 and scores.size(-1) == 1 else scores
+
+    def _select_fixed_k_positions(
+        self,
+        scores: torch.Tensor,
+        query_index: torch.Tensor,
+        target_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self.k_max <= 0:
+            raise RuntimeError('Fixed-k selection requested while k_max <= 0.')
+
+        score_tensor = self._score_tensor_for_mask_selection(scores)
+        num_top_queries = query_index.shape[1]
+        k_select = min(self.k_max, num_top_queries)
+        fill_value = torch.full_like(score_tensor, -1.0)
+        masked_scores = torch.where(target_mask, score_tensor, fill_value)
+        selected_scores, selected_pos = torch.topk(masked_scores, k_select, dim=1)
+        valid_selected = selected_scores > -0.5
+        selected_query_index = query_index.gather(dim=1, index=selected_pos)
+        return selected_pos, selected_query_index, valid_selected
+
+    def _scatter_selected_probs(
+        self,
+        selected_probs: torch.Tensor,
+        selected_pos: torch.Tensor,
+        valid_selected: torch.Tensor,
+        num_top_queries: int,
+    ) -> torch.Tensor:
+        batch_size, _, height, width = selected_probs.shape
+        full_probs = selected_probs.new_zeros((batch_size, num_top_queries, height, width))
+        scatter_index = selected_pos[:, :, None, None].expand(-1, -1, height, width)
+        selected_probs = selected_probs * valid_selected[:, :, None, None].to(selected_probs.dtype)
+        return full_probs.scatter(dim=1, index=scatter_index, src=selected_probs)
+
     def _compute_sparse_mask_probs_deploy(
         self,
         embeddings: torch.Tensor | None,
         feature_maps: torch.Tensor | None,
         query_index: torch.Tensor,
+        scores: torch.Tensor,
         target_mask: torch.Tensor,
     ) -> torch.Tensor | None:
         if embeddings is None or feature_maps is None:
             return None
+
+        if self.k_max > 0:
+            selected_pos, selected_query_index, valid_selected = self._select_fixed_k_positions(
+                scores,
+                query_index,
+                target_mask,
+            )
+            selected_embeds = self._gather_mask_embeddings(embeddings, selected_query_index)
+            selected_probs = torch.sigmoid(torch.einsum('bkc,bchw->bkhw', selected_embeds, feature_maps))
+            return self._scatter_selected_probs(
+                selected_probs,
+                selected_pos,
+                valid_selected,
+                query_index.shape[1],
+            )
 
         topk_embeddings = self._gather_mask_embeddings(embeddings, query_index)
         selected_positions = torch.nonzero(target_mask, as_tuple=False)
@@ -156,6 +212,7 @@ class PostProcessor(nn.Module):
         embeddings: torch.Tensor | None,
         feature_maps: torch.Tensor | None,
         query_index: torch.Tensor,
+        scores: torch.Tensor,
         orig_target_sizes: torch.Tensor | None,
         target_mask: torch.Tensor,
     ) -> torch.Tensor | list[torch.Tensor] | None:
@@ -163,7 +220,34 @@ class PostProcessor(nn.Module):
             return None
 
         if orig_target_sizes is None:
-            return self._compute_sparse_mask_probs_deploy(embeddings, feature_maps, query_index, target_mask)
+            return self._compute_sparse_mask_probs_deploy(embeddings, feature_maps, query_index, scores, target_mask)
+
+        if self.k_max > 0:
+            selected_pos, selected_query_index, valid_selected = self._select_fixed_k_positions(
+                scores,
+                query_index,
+                target_mask,
+            )
+            selected_embeddings = self._gather_mask_embeddings(embeddings, selected_query_index)
+            gathered = []
+            for batch_idx in range(selected_embeddings.shape[0]):
+                orig_w, orig_h = orig_target_sizes[batch_idx].tolist()
+                batch_output = feature_maps.new_zeros(
+                    (query_index.shape[1], 1, int(orig_h), int(orig_w))
+                )
+                selected_logits = torch.einsum(
+                    'kc,chw->khw',
+                    selected_embeddings[batch_idx],
+                    feature_maps[batch_idx],
+                )
+                resized_masks = self.resize_masks(
+                    selected_logits.unsqueeze(1),
+                    size=(int(orig_h), int(orig_w)),
+                ).sigmoid()
+                resized_masks = resized_masks * valid_selected[batch_idx, :, None, None].to(resized_masks.dtype)
+                batch_output[selected_pos[batch_idx]] = resized_masks
+                gathered.append(batch_output)
+            return gathered
 
         topk_embeddings = self._gather_mask_embeddings(embeddings, query_index)
         gathered = []
@@ -230,6 +314,7 @@ class PostProcessor(nn.Module):
                 mask_embed,
                 mask_features,
                 query_index,
+                scores,
                 orig_target_sizes,
                 target_mask,
             )
@@ -240,6 +325,7 @@ class PostProcessor(nn.Module):
                 contour_embeds,
                 contour_features,
                 query_index,
+                scores,
                 orig_target_sizes,
                 target_mask,
             )

--- a/engine/deim/postprocessor.py
+++ b/engine/deim/postprocessor.py
@@ -25,6 +25,7 @@ class PostProcessor(nn.Module):
         'num_classes',
         'use_focal_loss',
         'num_top_queries',
+        'mask_target_class_ids',
         'remap_mscoco_category',
         'mask_resize_origin',
     ]
@@ -34,6 +35,7 @@ class PostProcessor(nn.Module):
         num_classes=80,
         use_focal_loss=True,
         num_top_queries=300,
+        mask_target_class_ids=None,
         remap_mscoco_category=False,
         mask_resize_origin='center',
     ) -> None:
@@ -41,6 +43,7 @@ class PostProcessor(nn.Module):
         self.use_focal_loss = use_focal_loss
         self.num_top_queries = num_top_queries
         self.num_classes = int(num_classes)
+        self.mask_target_class_ids = [] if mask_target_class_ids is None else [int(x) for x in mask_target_class_ids]
         self.remap_mscoco_category = remap_mscoco_category
         self.deploy_mode = False
         self.mask_resize_origin = mask_resize_origin
@@ -108,6 +111,79 @@ class PostProcessor(nn.Module):
             return gathered
         return torch.stack(gathered, dim=0)
 
+    def _build_mask_target_mask(self, labels: torch.Tensor) -> torch.Tensor:
+        if not self.mask_target_class_ids:
+            return torch.ones_like(labels, dtype=torch.bool)
+        return torch.stack(
+            [labels == class_id for class_id in self.mask_target_class_ids],
+            dim=0,
+        ).any(dim=0)
+
+    def _gather_mask_embeddings(
+        self,
+        embeddings: torch.Tensor,
+        query_index: torch.Tensor,
+    ) -> torch.Tensor:
+        gather_index = query_index.unsqueeze(-1).expand(-1, -1, embeddings.shape[-1])
+        return embeddings.gather(dim=1, index=gather_index)
+
+    def _compute_sparse_mask_probs_deploy(
+        self,
+        embeddings: torch.Tensor | None,
+        feature_maps: torch.Tensor | None,
+        query_index: torch.Tensor,
+        target_mask: torch.Tensor,
+    ) -> torch.Tensor | None:
+        if embeddings is None or feature_maps is None:
+            return None
+
+        topk_embeddings = self._gather_mask_embeddings(embeddings, query_index)
+        selected_positions = torch.nonzero(target_mask, as_tuple=False)
+        selected_embeddings = topk_embeddings[selected_positions[:, 0], selected_positions[:, 1]]
+        selected_feature_maps = feature_maps[selected_positions[:, 0]]
+        selected_probs = torch.sigmoid(torch.einsum('mc,mchw->mhw', selected_embeddings, selected_feature_maps))
+
+        batch_size, num_queries = query_index.shape
+        height, width = feature_maps.shape[-2:]
+        flat_output = feature_maps.new_zeros((batch_size * num_queries, height, width))
+        flat_indices = selected_positions[:, 0] * num_queries + selected_positions[:, 1]
+        scatter_index = flat_indices[:, None, None].expand(-1, height, width)
+        flat_output = flat_output.scatter(0, scatter_index, selected_probs)
+        return flat_output.reshape(batch_size, num_queries, height, width)
+
+    def _compute_sparse_mask_probs(
+        self,
+        embeddings: torch.Tensor | None,
+        feature_maps: torch.Tensor | None,
+        query_index: torch.Tensor,
+        orig_target_sizes: torch.Tensor | None,
+        target_mask: torch.Tensor,
+    ) -> torch.Tensor | list[torch.Tensor] | None:
+        if embeddings is None or feature_maps is None:
+            return None
+
+        if orig_target_sizes is None:
+            return self._compute_sparse_mask_probs_deploy(embeddings, feature_maps, query_index, target_mask)
+
+        topk_embeddings = self._gather_mask_embeddings(embeddings, query_index)
+        gathered = []
+        for batch_idx in range(topk_embeddings.shape[0]):
+            orig_w, orig_h = orig_target_sizes[batch_idx].tolist()
+            batch_output = feature_maps.new_zeros(
+                (topk_embeddings.shape[1], 1, int(orig_h), int(orig_w))
+            )
+            selected_queries = torch.nonzero(target_mask[batch_idx], as_tuple=False).flatten()
+            if selected_queries.numel() > 0:
+                selected_embeddings = topk_embeddings[batch_idx, selected_queries]
+                selected_logits = torch.einsum('qc,chw->qhw', selected_embeddings, feature_maps[batch_idx])
+                resized_masks = self.resize_masks(
+                    selected_logits.unsqueeze(1),
+                    size=(int(orig_h), int(orig_w)),
+                ).sigmoid()
+                batch_output[selected_queries] = resized_masks
+            gathered.append(batch_output)
+        return gathered
+
     # def forward(self, outputs, orig_target_sizes):
     def forward(
         self,
@@ -115,10 +191,14 @@ class PostProcessor(nn.Module):
         orig_target_sizes: torch.Tensor=None,
         return_masks: bool=True,
         return_contours: bool=False,
-    ):
+        ):
         logits, boxes = outputs['pred_logits'], outputs['pred_boxes']
         pred_masks = outputs.get('pred_masks') if return_masks else None
         pred_contours = outputs.get('pred_mask_contours') if return_contours else None
+        mask_embed = outputs.get('mask_embed') if return_masks else None
+        mask_features = outputs.get('mask_features') if return_masks else None
+        contour_embeds = outputs.get('pred_mask_contour_embeds') if return_contours else None
+        contour_features = outputs.get('pred_mask_contour_features') if return_contours else None
         bbox_pred = self.box_cxcywh_to_xyxy(boxes)
         if orig_target_sizes is not None:
             bbox_pred *= orig_target_sizes.repeat(1, 2).unsqueeze(1)
@@ -143,8 +223,26 @@ class PostProcessor(nn.Module):
                 query_index = torch.arange(scores.shape[1], device=logits.device).unsqueeze(0).expand(scores.shape[0], -1)
                 boxes = bbox_pred
 
+        target_mask = self._build_mask_target_mask(labels)
         gathered_masks = self._gather_mask_like(pred_masks, query_index, orig_target_sizes)
+        if gathered_masks is None and return_masks:
+            gathered_masks = self._compute_sparse_mask_probs(
+                mask_embed,
+                mask_features,
+                query_index,
+                orig_target_sizes,
+                target_mask,
+            )
+
         gathered_contours = self._gather_mask_like(pred_contours, query_index, orig_target_sizes)
+        if gathered_contours is None and return_contours:
+            gathered_contours = self._compute_sparse_mask_probs(
+                contour_embeds,
+                contour_features,
+                query_index,
+                orig_target_sizes,
+                target_mask,
+            )
 
         if self.deploy_mode:
             if orig_target_sizes is not None and (gathered_masks is not None or gathered_contours is not None):

--- a/tools/deployment/README.md
+++ b/tools/deployment/README.md
@@ -180,6 +180,62 @@ uv run onnxsim ${WEIGHT}_${QUERIES}query_n_batch.onnx ${WEIGHT}_${QUERIES}query.
 uv run python tools/deployment/make_prep.py -m ${WEIGHT}_${QUERIES}query.onnx -s 1 3 ${H} ${W}
 ```
 
+## `PostProcessor.k_max` for instance segmentation
+
+For `*_ins.yml` instance segmentation models, `PostProcessor.k_max` controls how many detections are allowed to enter the mask computation path during inference and ONNX export.
+
+- `k_max: 0` (default)
+  - Keeps the current sparse variable-length path.
+  - The exported ONNX graph uses `NonZero` to compact only the detections whose predicted class is included in `mask_target_class_ids`.
+  - This gives the smallest amount of mask computation when the actual number of target detections is very small.
+- `k_max: N` where `N >= 1`
+  - Switches inference and ONNX export to a fixed-length `TopK` path.
+  - Only the top `N` detections among `mask_target_class_ids` are used for mask computation.
+  - The exported ONNX graph removes `NonZero` and uses `TopK + Gather + ScatterElements` instead.
+  - This is intended for runtimes such as TensorRT where avoiding `NonZero` is preferable.
+
+Important points:
+
+- `k_max` affects only inference and ONNX export. It does not change the training loss path.
+- `k_max` is a limit for the mask computation path, not for bbox detection itself.
+- `label_xyxy_score` output shape does not change.
+- `masks` output shape does not change.
+- Detections that are not selected for mask computation are returned as zero masks.
+- If the actual number of target detections is less than or equal to `k_max`, the mask result should match the `k_max: 0` path apart from graph structure differences.
+- If the actual number of target detections is greater than `k_max`, only the highest-score `k_max` detections in `mask_target_class_ids` receive masks.
+
+Example config:
+
+```yaml
+PostProcessor:
+  num_top_queries: 800
+  k_max: 32
+```
+
+You can also override it only at export time without editing the YAML file:
+
+```bash
+uv run python tools/deployment/export_onnx.py \
+-c configs/deimv2/deimv2_dinov3_x_wholebody40_ins_s08.yml \
+-r ckpts/deimv2_dinov3_x_wholebody40_ins_s08.pth \
+--opset 17 \
+--with-masks \
+-u PostProcessor.k_max=32
+```
+
+For the command above:
+
+- `label_xyxy_score` remains `[B, 800, 6]`
+- `masks` remains `[B, 800, H, W]`
+- only up to `32` target detections go through the actual mask `einsum`
+- non-selected rows in `masks` are filled with zeros
+
+Recommended usage:
+
+- Use `k_max: 0` when you want the most faithful sparse path and your runtime tolerates `NonZero`.
+- Use `k_max: 16`, `32`, or `48` when you want a fixed-size ONNX graph for TensorRT-oriented deployment.
+- Set `k_max` large enough to cover the expected maximum number of target instances in one image. For example, if at most about 20 persons are expected, `k_max: 32` is a practical starting point.
+
 <img width="808" height="704" alt="image" src="https://github.com/user-attachments/assets/82606a50-c294-43f2-b617-a653a6ba5424" />
 
 ```bash

--- a/tools/deployment/export_onnx.py
+++ b/tools/deployment/export_onnx.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../
 import torch
 import torch.nn as nn
 
-from engine.core import YAMLConfig
+from engine.core import YAMLConfig, yaml_utils
 
 
 @contextmanager
@@ -44,7 +44,9 @@ def patch_non_tensor_extra_state(module: nn.Module):
 def main(args, ):
     """main
     """
-    cfg = YAMLConfig(args.config, resume=args.resume)
+    update_dict = yaml_utils.parse_cli(args.update)
+    update_dict.update({'resume': args.resume})
+    cfg = YAMLConfig(args.config, **update_dict)
 
     if 'HGNetv2' in cfg.yaml_cfg:
         cfg.yaml_cfg['HGNetv2']['pretrained'] = False
@@ -218,6 +220,7 @@ if __name__ == '__main__':
     parser.add_argument('--simplify',  action='store_true')
     parser.add_argument('--skip_onnxslim',  action='store_true')
     parser.add_argument('--dynamic_batch',  action='store_true')
+    parser.add_argument('-u', '--update', nargs='+', help='update yaml config')
     parser.add_argument('--fp16', '-f', action='store_true')
     parser.add_argument('--with-masks', action='store_true')
     parser.add_argument('--with-contours', action='store_true')

--- a/tools/deployment/export_onnx.py
+++ b/tools/deployment/export_onnx.py
@@ -47,10 +47,21 @@ def main(args, ):
             super().__init__()
             self.model = cfg.model.deploy()
             self.postprocessor = cfg.postprocessor.deploy()
+            self.return_masks = args.with_masks
+            self.return_contours = args.with_contours
 
         def forward(self, images, orig_target_sizes: torch.Tensor=None):
-            outputs = self.model(images)
-            outputs = self.postprocessor(outputs, orig_target_sizes)
+            outputs = self.model(
+                images,
+                return_masks=self.return_masks,
+                return_contours=self.return_contours,
+            )
+            outputs = self.postprocessor(
+                outputs,
+                orig_target_sizes,
+                return_masks=self.return_masks,
+                return_contours=self.return_contours,
+            )
             return outputs
 
     model = Model()
@@ -63,15 +74,30 @@ def main(args, ):
     data = torch.rand(1, 3, *img_size)
     _ = model(data)
 
+    output_names = ['label_xyxy_score']
+    if args.with_masks:
+        output_names.append('masks')
+    if args.with_contours:
+        output_names.append('contours')
+
     dynamic_axes = {}
     if args.dynamic_batch:
         dynamic_axes = {
             'images': {0: 'N'},
             'label_xyxy_score': {0: 'N', 1: str(num_queries), 2: '6'},
         }
+        if args.with_masks:
+            dynamic_axes['masks'] = {0: 'N', 1: str(num_queries)}
+        if args.with_contours:
+            dynamic_axes['contours'] = {0: 'N', 1: str(num_queries)}
 
-    output_file = f'{os.path.splitext(os.path.basename(args.config))[0]}_{num_queries}query.onnx'
+    output_file = f'{os.path.splitext(os.path.basename(args.config))[0]}_{num_queries}query'
+    if args.with_masks:
+        output_file = f'{output_file}_masks'
+    if args.with_contours:
+        output_file = f'{output_file}_contours'
     fp16_txt = '' if not args.fp16 else '_fp16'
+    export_path = f'{output_file}{"_n_batch" if args.dynamic_batch else ""}{fp16_txt}.onnx'
 
     if not args.dynamic_batch:
         if not args.fp16:
@@ -82,9 +108,9 @@ def main(args, ):
             torch.onnx.export(
                 model,
                 (data),
-                f'{os.path.splitext(os.path.basename(output_file))[0]}{fp16_txt}.onnx',
+                export_path,
                 input_names=['images'],
-                output_names=['label_xyxy_score'],
+                output_names=output_names,
                 dynamic_axes=None,
                 opset_version=17,
             )
@@ -98,9 +124,9 @@ def main(args, ):
                 torch.onnx.export(
                     model,
                     (data),
-                    f'{os.path.splitext(os.path.basename(output_file))[0]}{fp16_txt}.onnx',
+                    export_path,
                     input_names=['images'],
-                    output_names=['label_xyxy_score'],
+                    output_names=output_names,
                     dynamic_axes=None,
                     opset_version=17,
                 )
@@ -113,9 +139,9 @@ def main(args, ):
             torch.onnx.export(
                 model,
                 (data),
-                f'{os.path.splitext(os.path.basename(output_file))[0]}_n_batch{fp16_txt}.onnx',
+                export_path,
                 input_names=['images'],
-                output_names=['label_xyxy_score'],
+                output_names=output_names,
                 dynamic_axes=dynamic_axes,
                 opset_version=17,
             )
@@ -129,16 +155,16 @@ def main(args, ):
                 torch.onnx.export(
                     model,
                     (data),
-                    f'{os.path.splitext(os.path.basename(output_file))[0]}_n_batch{fp16_txt}.onnx',
+                    export_path,
                     input_names=['images'],
-                    output_names=['label_xyxy_score'],
+                    output_names=output_names,
                     dynamic_axes=dynamic_axes,
                     opset_version=17,
                 )
 
     if args.check:
         import onnx
-        onnx_model = onnx.load(output_file)
+        onnx_model = onnx.load(export_path)
         onnx.checker.check_model(onnx_model)
         print('Check export onnx model done...')
 
@@ -147,11 +173,11 @@ def main(args, ):
         import onnxsim
         import onnxslim
         if not args.skip_onnxslim:
-            onnx_model_slim = onnxslim.slim(output_file)
+            onnx_model_slim = onnxslim.slim(export_path)
             onnx_model_simplify, check = onnxsim.simplify(onnx_model_slim)
         else:
-            onnx_model_simplify, check = onnxsim.simplify(output_file)
-        onnx.save(onnx_model_simplify, output_file)
+            onnx_model_simplify, check = onnxsim.simplify(export_path)
+        onnx.save(onnx_model_simplify, export_path)
         print(f'Simplify onnx model {check}...')
 
 
@@ -168,5 +194,7 @@ if __name__ == '__main__':
     parser.add_argument('--skip_onnxslim',  action='store_true')
     parser.add_argument('--dynamic_batch',  action='store_true')
     parser.add_argument('--fp16', '-f', action='store_true')
+    parser.add_argument('--with-masks', action='store_true')
+    parser.add_argument('--with-contours', action='store_true')
     args = parser.parse_args()
     main(args)

--- a/tools/deployment/export_onnx.py
+++ b/tools/deployment/export_onnx.py
@@ -11,6 +11,7 @@ Copyright (c) 2023 lyuwenyu. All Rights Reserved.
 
 import os
 import sys
+from contextlib import contextmanager
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..'))
 
@@ -18,6 +19,26 @@ import torch
 import torch.nn as nn
 
 from engine.core import YAMLConfig
+
+
+@contextmanager
+def patch_non_tensor_extra_state(module: nn.Module):
+    patched = []
+    for submodule in module.modules():
+        if type(submodule).get_extra_state is nn.Module.get_extra_state:
+            continue
+        extra_state = submodule.get_extra_state()
+        if torch.is_tensor(extra_state):
+            continue
+        original = submodule.get_extra_state
+        submodule.get_extra_state = lambda: torch.empty(0)
+        patched.append((submodule, original))
+
+    try:
+        yield
+    finally:
+        for submodule, original in patched:
+            submodule.get_extra_state = original
 
 
 def main(args, ):
@@ -105,22 +126,7 @@ def main(args, ):
             data = torch.randn(1, 3, h, w)
             _ = model(data)
 
-            torch.onnx.export(
-                model,
-                (data),
-                export_path,
-                input_names=['images'],
-                output_names=output_names,
-                dynamic_axes=None,
-                opset_version=17,
-            )
-        else:
-            model.cuda()
-            with torch.autocast("cuda", dtype=torch.float16):
-                h, w = args.size
-                data = torch.randn(1, 3, h, w, device="cuda")
-                _ = model(data)
-
+            with patch_non_tensor_extra_state(model):
                 torch.onnx.export(
                     model,
                     (data),
@@ -128,23 +134,8 @@ def main(args, ):
                     input_names=['images'],
                     output_names=output_names,
                     dynamic_axes=None,
-                    opset_version=17,
+                    opset_version=args.opset,
                 )
-    else:
-        if not args.fp16:
-            h, w = args.size
-            data = torch.randn(1, 3, h, w)
-            _ = model(data)
-
-            torch.onnx.export(
-                model,
-                (data),
-                export_path,
-                input_names=['images'],
-                output_names=output_names,
-                dynamic_axes=dynamic_axes,
-                opset_version=17,
-            )
         else:
             model.cuda()
             with torch.autocast("cuda", dtype=torch.float16):
@@ -152,6 +143,23 @@ def main(args, ):
                 data = torch.randn(1, 3, h, w, device="cuda")
                 _ = model(data)
 
+                with patch_non_tensor_extra_state(model):
+                    torch.onnx.export(
+                        model,
+                        (data),
+                        export_path,
+                        input_names=['images'],
+                        output_names=output_names,
+                        dynamic_axes=None,
+                        opset_version=args.opset,
+                    )
+    else:
+        if not args.fp16:
+            h, w = args.size
+            data = torch.randn(1, 3, h, w)
+            _ = model(data)
+
+            with patch_non_tensor_extra_state(model):
                 torch.onnx.export(
                     model,
                     (data),
@@ -159,8 +167,25 @@ def main(args, ):
                     input_names=['images'],
                     output_names=output_names,
                     dynamic_axes=dynamic_axes,
-                    opset_version=17,
+                    opset_version=args.opset,
                 )
+        else:
+            model.cuda()
+            with torch.autocast("cuda", dtype=torch.float16):
+                h, w = args.size
+                data = torch.randn(1, 3, h, w, device="cuda")
+                _ = model(data)
+
+                with patch_non_tensor_extra_state(model):
+                    torch.onnx.export(
+                        model,
+                        (data),
+                        export_path,
+                        input_names=['images'],
+                        output_names=output_names,
+                        dynamic_axes=dynamic_axes,
+                        opset_version=args.opset,
+                    )
 
     if args.check:
         import onnx

--- a/tools/inference/onnx_inf.py
+++ b/tools/inference/onnx_inf.py
@@ -55,6 +55,18 @@ def draw(images, labels, boxes, scores, ratios, paddings, thrh=0.4):
     return result_images
 
 
+def decode_outputs(output_names, output_values):
+    outputs = dict(zip(output_names, output_values))
+    if 'label_xyxy_score' in outputs:
+        label_xyxy_score = outputs['label_xyxy_score']
+        labels = label_xyxy_score[..., 0].astype(np.int64)
+        boxes = label_xyxy_score[..., 1:5]
+        scores = label_xyxy_score[..., 5]
+    else:
+        labels, boxes, scores = output_values[:3]
+    return labels, boxes, scores, outputs
+
+
 def process_image(sess, im_pil, size=640, model_size='s'):
     # Resize image while preserving aspect ratio
     resized_im_pil, ratio, pad_w, pad_h = resize_with_aspect_ratio(im_pil, size)
@@ -68,12 +80,12 @@ def process_image(sess, im_pil, size=640, model_size='s'):
         ])
     im_data = transforms(resized_im_pil).unsqueeze(0)
 
-    output = sess.run(
-        output_names=None,
-        input_feed={'images': im_data.numpy(), "orig_target_sizes": orig_size.numpy()}
-    )
-
-    labels, boxes, scores = output
+    input_feed = {'images': im_data.numpy()}
+    if any(inp.name == 'orig_target_sizes' for inp in sess.get_inputs()):
+        input_feed['orig_target_sizes'] = orig_size.numpy()
+    output_names = [out.name for out in sess.get_outputs()]
+    output = sess.run(output_names=output_names, input_feed=input_feed)
+    labels, boxes, scores, _ = decode_outputs(output_names, output)
 
     result_images = draw(
         [im_pil], labels, boxes, scores,
@@ -117,12 +129,12 @@ def process_video(sess, video_path, size=640, model_size='s'):
             ])
         im_data = transforms(resized_frame_pil).unsqueeze(0)
 
-        output = sess.run(
-            output_names=None,
-            input_feed={'images': im_data.numpy(), "orig_target_sizes": orig_size.numpy()}
-        )
-
-        labels, boxes, scores = output
+        input_feed = {'images': im_data.numpy()}
+        if any(inp.name == 'orig_target_sizes' for inp in sess.get_inputs()):
+            input_feed['orig_target_sizes'] = orig_size.numpy()
+        output_names = [out.name for out in sess.get_outputs()]
+        output = sess.run(output_names=output_names, input_feed=input_feed)
+        labels, boxes, scores, _ = decode_outputs(output_names, output)
 
         # Draw detections on the original frame
         result_images = draw(

--- a/tools/inference/torch_inf.py
+++ b/tools/inference/torch_inf.py
@@ -136,8 +136,13 @@ def main(args):
             self.postprocessor = cfg.postprocessor.deploy()
 
         def forward(self, images, orig_target_sizes):
-            outputs = self.model(images)
-            outputs = self.postprocessor(outputs, orig_target_sizes)
+            outputs = self.model(images, return_masks=False, return_contours=False)
+            outputs = self.postprocessor(
+                outputs,
+                orig_target_sizes,
+                return_masks=False,
+                return_contours=False,
+            )
             return outputs
 
     device = args.device


### PR DESCRIPTION
This pull request introduces significant enhancements to the DEIMv2 whole-body instance segmentation pipeline, focusing on improved mask handling, boundary-aware loss, and expanded ONNX/TensorRT inference support. The changes affect multiple configuration files and the demo script, enabling more advanced mask processing and easier deployment using ONNX and TensorRT.

Key changes include:

**Model Configuration Improvements:**

- Enabled auxiliary heads for contour and distance prediction, set `mask_compute_mode` to `lazy`, and added mask embedding head parameters in `DEIMTransformer` for all relevant config files, improving mask quality and model flexibility. (`[[1]](diffhunk://#diff-b0f298dbcf56e2e56bb86e153c452bda4eb24f86d22dac1ddd613821a7573556L36-R46)`, `[[2]](diffhunk://#diff-60a4931cdba6f6f00e566204b570ddb71d7f3cfa6f7e80da9d59883993b96db8L36-R46)`, `[[3]](diffhunk://#diff-5c257fa8a853dcc75e23b36382e08b8c153d168278825565a3e21d7b0a7618e0L36-R46)`, `[[4]](diffhunk://#diff-0b3f07358fbcd41720a070edca08bb0fcce94da896e23e9876d999767d2337efR39-R48)`, `[[5]](diffhunk://#diff-8fa9067bac3870a22b18c71afc5804db0b31abe26b290ac570293377321a776aR39-R48)`, `[[6]](diffhunk://#diff-0f80e235d4ffbc147709648db5abc6d873084f3f864411de21e1721131721845L44-R54)`, `[[7]](diffhunk://#diff-62bf95ff044f1c1b905aeda1927a651976477523476ed61ec2fa434f89335bd5L45-R55)`, `[[8]](diffhunk://#diff-e45d0e48e52adbe4d682405618f6de9ab976b6b2758c96d5af8d58d5a11cf97dL43-R53)`, `[[9]](diffhunk://#diff-f849882e51fb1f7de8e1c78b6f2113ec27068de3a158c7c61fe6c8e71c5c53c7L46-R56)`)
- Switched on boundary-aware loss, contour detection, and distance transform in `DEIMCriterion` across all configs to enhance mask accuracy, especially at object boundaries. (`[[1]](diffhunk://#diff-b0f298dbcf56e2e56bb86e153c452bda4eb24f86d22dac1ddd613821a7573556L121-R130)`, `[[2]](diffhunk://#diff-60a4931cdba6f6f00e566204b570ddb71d7f3cfa6f7e80da9d59883993b96db8L121-R130)`, `[[3]](diffhunk://#diff-5c257fa8a853dcc75e23b36382e08b8c153d168278825565a3e21d7b0a7618e0L121-R130)`, `[[4]](diffhunk://#diff-0f80e235d4ffbc147709648db5abc6d873084f3f864411de21e1721131721845L128-R137)`, `[[5]](diffhunk://#diff-62bf95ff044f1c1b905aeda1927a651976477523476ed61ec2fa434f89335bd5L133-R142)`, `[[6]](diffhunk://#diff-e45d0e48e52adbe4d682405618f6de9ab976b6b2758c96d5af8d58d5a11cf97dL129-R138)`, `[[7]](diffhunk://#diff-f849882e51fb1f7de8e1c78b6f2113ec27068de3a158c7c61fe6c8e71c5c53c7L133-R142)`)
- Added `mask_target_class_ids: [0]` to configs, focusing mask prediction on the primary class (likely "person"). (`[[1]](diffhunk://#diff-b0f298dbcf56e2e56bb86e153c452bda4eb24f86d22dac1ddd613821a7573556R10)`, `[[2]](diffhunk://#diff-60a4931cdba6f6f00e566204b570ddb71d7f3cfa6f7e80da9d59883993b96db8R10)`, `[[3]](diffhunk://#diff-5c257fa8a853dcc75e23b36382e08b8c153d168278825565a3e21d7b0a7618e0R10)`, `[[4]](diffhunk://#diff-0b3f07358fbcd41720a070edca08bb0fcce94da896e23e9876d999767d2337efR11)`, `[[5]](diffhunk://#diff-8fa9067bac3870a22b18c71afc5804db0b31abe26b290ac570293377321a776aR11)`, `[[6]](diffhunk://#diff-0f80e235d4ffbc147709648db5abc6d873084f3f864411de21e1721131721845R10)`, `[[7]](diffhunk://#diff-62bf95ff044f1c1b905aeda1927a651976477523476ed61ec2fa434f89335bd5R10)`, `[[8]](diffhunk://#diff-e45d0e48e52adbe4d682405618f6de9ab976b6b2758c96d5af8d58d5a11cf97dR10)`, `[[9]](diffhunk://#diff-f849882e51fb1f7de8e1c78b6f2113ec27068de3a158c7c61fe6c8e71c5c53c7R10)`)
- Introduced `k_max: 0` in `PostProcessor` for all configs, likely to control the number of mask proposals. (`[[1]](diffhunk://#diff-b0f298dbcf56e2e56bb86e153c452bda4eb24f86d22dac1ddd613821a7573556L36-R46)`, `[[2]](diffhunk://#diff-60a4931cdba6f6f00e566204b570ddb71d7f3cfa6f7e80da9d59883993b96db8L36-R46)`, `[[3]](diffhunk://#diff-5c257fa8a853dcc75e23b36382e08b8c153d168278825565a3e21d7b0a7618e0L36-R46)`, `[[4]](diffhunk://#diff-0b3f07358fbcd41720a070edca08bb0fcce94da896e23e9876d999767d2337efR39-R48)`, `[[5]](diffhunk://#diff-8fa9067bac3870a22b18c71afc5804db0b31abe26b290ac570293377321a776aR39-R48)`, `[[6]](diffhunk://#diff-0f80e235d4ffbc147709648db5abc6d873084f3f864411de21e1721131721845L44-R54)`, `[[7]](diffhunk://#diff-62bf95ff044f1c1b905aeda1927a651976477523476ed61ec2fa434f89335bd5L45-R55)`, `[[8]](diffhunk://#diff-e45d0e48e52adbe4d682405618f6de9ab976b6b2758c96d5af8d58d5a11cf97dL43-R53)`, `[[9]](diffhunk://#diff-f849882e51fb1f7de8e1c78b6f2113ec27068de3a158c7c61fe6c8e71c5c53c7L46-R56)`)

**Demo Script and Inference Enhancements:**

- Added ONNX and TensorRT inference support to the demo script, including device/provider selection and inference type (FP16/INT8) configuration, enabling efficient deployment and hardware acceleration. (`[demo/wholebody40/demo_deimv2_torch_wholebody40_ins.pyR174-R228](diffhunk://#diff-9f5f9365ebbdd0559252afa78b27c37f6210f75d2c1acbc20e5b3eac3375298eR174-R228)`)
- Updated the demo script to handle mask and contour outputs conditionally, and improved payload preparation for downstream processing. (`[demo/wholebody40/demo_deimv2_torch_wholebody40_ins.pyR439-R447](diffhunk://#diff-9f5f9365ebbdd0559252afa78b27c37f6210f75d2c1acbc20e5b3eac3375298eR439-R447)`)
- Updated the README with instructions and examples for ONNX and TensorRT usage, making it easier for users to leverage these features. (`[[1]](diffhunk://#diff-717cb4c54403d3ff568f8ad5da5fb430c2fea698519081cad6308ed3cfc3651aR126-R154)`, `[[2]](diffhunk://#diff-717cb4c54403d3ff568f8ad5da5fb430c2fea698519081cad6308ed3cfc3651aL115-R116)`)

**Other Notable Changes:**

- Updated imports in the demo script to include new utilities for config loading and mask resizing. (`[demo/wholebody40/demo_deimv2_torch_wholebody40_ins.pyL25-R26](diffhunk://#diff-9f5f9365ebbdd0559252afa78b27c37f6210f75d2c1acbc20e5b3eac3375298eL25-R26)`)

These updates collectively improve segmentation quality, provide advanced mask processing, and make the pipeline more user-friendly and deployable on various hardware backends.

---

**References:**
- Model configuration: (`[[1]](diffhunk://#diff-b0f298dbcf56e2e56bb86e153c452bda4eb24f86d22dac1ddd613821a7573556L36-R46)`, `[[2]](diffhunk://#diff-60a4931cdba6f6f00e566204b570ddb71d7f3cfa6f7e80da9d59883993b96db8L36-R46)`, `[[3]](diffhunk://#diff-5c257fa8a853dcc75e23b36382e08b8c153d168278825565a3e21d7b0a7618e0L36-R46)`, `[[4]](diffhunk://#diff-0b3f07358fbcd41720a070edca08bb0fcce94da896e23e9876d999767d2337efR39-R48)`, `[[5]](diffhunk://#diff-8fa9067bac3870a22b18c71afc5804db0b31abe26b290ac570293377321a776aR39-R48)`, `[[6]](diffhunk://#diff-0f80e235d4ffbc147709648db5abc6d873084f3f864411de21e1721131721845L44-R54)`, `[[7]](diffhunk://#diff-62bf95ff044f1c1b905aeda1927a651976477523476ed61ec2fa434f89335bd5L45-R55)`, `[[8]](diffhunk://#diff-e45d0e48e52adbe4d682405618f6de9ab976b6b2758c96d5af8d58d5a11cf97dL43-R53)`, `[[9]](diffhunk://#diff-f849882e51fb1f7de8e1c78b6f2113ec27068de3a158c7c61fe6c8e71c5c53c7L46-R56)`)
- Boundary-aware loss and mask focus: (`[[1]](diffhunk://#diff-b0f298dbcf56e2e56bb86e153c452bda4eb24f86d22dac1ddd613821a7573556L121-R130)`, `[[2]](diffhunk://#diff-60a4931cdba6f6f00e566204b570ddb71d7f3cfa6f7e80da9d59883993b96db8L121-R130)`, `[[3]](diffhunk://#diff-5c257fa8a853dcc75e23b36382e08b8c153d168278825565a3e21d7b0a7618e0L121-R130)`, `[[4]](diffhunk://#diff-0f80e235d4ffbc147709648db5abc6d873084f3f864411de21e1721131721845L128-R137)`, `[[5]](diffhunk://#diff-62bf95ff044f1c1b905aeda1927a651976477523476ed61ec2fa434f89335bd5L133-R142)`, `[[6]](diffhunk://#diff-e45d0e48e52adbe4d682405618f6de9ab976b6b2758c96d5af8d58d5a11cf97dL129-R138)`, `[[7]](diffhunk://#diff-f849882e51fb1f7de8e1c78b6f2113ec27068de3a158c7c61fe6c8e71c5c53c7L133-R142)`, `[[8]](diffhunk://#diff-b0f298dbcf56e2e56bb86e153c452bda4eb24f86d22dac1ddd613821a7573556R10)`, `[[9]](diffhunk://#diff-60a4931cdba6f6f00e566204b570ddb71d7f3cfa6f7e80da9d59883993b96db8R10)`, `[[10]](diffhunk://#diff-5c257fa8a853dcc75e23b36382e08b8c153d168278825565a3e21d7b0a7618e0R10)`, `[[11]](diffhunk://#diff-0b3f07358fbcd41720a070edca08bb0fcce94da896e23e9876d999767d2337efR11)`, `[[12]](diffhunk://#diff-8fa9067bac3870a22b18c71afc5804db0b31abe26b290ac570293377321a776aR11)`, `[[13]](diffhunk://#diff-0f80e235d4ffbc147709648db5abc6d873084f3f864411de21e1721131721845R10)`, `[[14]](diffhunk://#diff-62bf95ff044f1c1b905aeda1927a651976477523476ed61ec2fa434f89335bd5R10)`, `[[15]](diffhunk://#diff-e45d0e48e52adbe4d682405618f6de9ab976b6b2758c96d5af8d58d5a11cf97dR10)`, `[[16]](diffhunk://#diff-f849882e51fb1f7de8e1c78b6f2113ec27068de3a158c7c61fe6c8e71c5c53c7R10)`)
- Post-processing: (`[[1]](diffhunk://#diff-b0f298dbcf56e2e56bb86e153c452bda4eb24f86d22dac1ddd613821a7573556L36-R46)`, `[[2]](diffhunk://#diff-60a4931cdba6f6f00e566204b570ddb71d7f3cfa6f7e80da9d59883993b96db8L36-R46)`, `[[3]](diffhunk://#diff-5c257fa8a853dcc75e23b36382e08b8c153d168278825565a3e21d7b0a7618e0L36-R46)`, `[[4]](diffhunk://#diff-0b3f07358fbcd41720a070edca08bb0fcce94da896e23e9876d999767d2337efR39-R48)`, `[[5]](diffhunk://#diff-8fa9067bac3870a22b18c71afc5804db0b31abe26b290ac570293377321a776aR39-R48)`, `[[6]](diffhunk://#diff-0f80e235d4ffbc147709648db5abc6d873084f3f864411de21e1721131721845L44-R54)`, `[[7]](diffhunk://#diff-62bf95ff044f1c1b905aeda1927a651976477523476ed61ec2fa434f89335bd5L45-R55)`, `[[8]](diffhunk://#diff-e45d0e48e52adbe4d682405618f6de9ab976b6b2758c96d5af8d58d5a11cf97dL43-R53)`, `[[9]](diffhunk://#diff-f849882e51fb1f7de8e1c78b6f2113ec27068de3a158c7c61fe6c8e71c5c53c7L46-R56)`)
- Demo and ONNX/TensorRT support: (`[[1]](diffhunk://#diff-9f5f9365ebbdd0559252afa78b27c37f6210f75d2c1acbc20e5b3eac3375298eR174-R228)`, `[[2]](diffhunk://#diff-9f5f9365ebbdd0559252afa78b27c37f6210f75d2c1acbc20e5b3eac3375298eR439-R447)`, `[[3]](diffhunk://#diff-717cb4c54403d3ff568f8ad5da5fb430c2fea698519081cad6308ed3cfc3651aR126-R154)`, `[[4]](diffhunk://#diff-717cb4c54403d3ff568f8ad5da5fb430c2fea698519081cad6308ed3cfc3651aL115-R116)`, `[[5]](diffhunk://#diff-9f5f9365ebbdd0559252afa78b27c37f6210f75d2c1acbc20e5b3eac3375298eL25-R26)`)